### PR TITLE
feat: add simple memory profilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 include flags.mk
 
-CFLAGS := $(CFLAGS) -DMEMORY_PROFILE=$(PROFILE)
+ifeq ($(PROFILE),1)
+	CFLAGS := $(CFLAGS) -DMEMORY_PROFILE
+endif
 
 .PHONY: all
 all: clean bin/repl

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include flags.mk
 
+CFLAGS := $(CFLAGS) -DMEMORY_PROFILE=$(PROFILE)
+
 .PHONY: all
 all: clean bin/repl
 
@@ -27,7 +29,7 @@ tests/fmt.test: lifp/fmt.o lifp/node.o lib/arena.o lib/list.o lifp/value.o
 
 tests/integration.test: lifp/tokenize.o lifp/parse.o lib/arena.o lifp/evaluate.o lib/list.o lib/map.o lifp/node.o lifp/environment.o lifp/value.o
 
-bin/repl: lifp/tokenize.o lifp/parse.o lib/list.o lifp/evaluate.o lifp/node.o lib/arena.o lifp/environment.o lib/map.o lifp/fmt.o lifp/value.o linenoise.o
+bin/repl: lifp/tokenize.o lifp/parse.o lib/list.o lifp/evaluate.o lifp/node.o lib/arena.o lifp/environment.o lib/map.o lib/profile.o lifp/fmt.o lifp/value.o linenoise.o
 bin/run: lifp/tokenize.o lifp/parse.o lib/list.o lifp/evaluate.o lifp/node.o lib/arena.o lifp/environment.o lib/map.o lifp/fmt.o lifp/value.o
 
 

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -95,8 +95,8 @@ int main(void) {
   }
   profileEnd();
   environmentDestroy(&global_environment);
-  arenaDestroy(temp_arena);
-  arenaDestroy(ast_arena);
+  arenaDestroy(&temp_arena);
+  arenaDestroy(&ast_arena);
   return 0;
 }
 

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include <string.h>
 
+allocationProfileInit();
+
 // Size of the output buffer
 constexpr size_t BUFFER_SIZE = 4096;
 
@@ -58,6 +60,8 @@ int main(void) {
 
   linenoiseSetMultiLine(1);
 
+  allocationProfileReport();
+
   while (true) {
     arenaReset(ast_arena);
     arenaReset(temp_arena);
@@ -88,10 +92,12 @@ int main(void) {
     printf("~> %s\n", buffer);
 
     memset(buffer, 0, BUFFER_SIZE);
+    allocationProfileReport();
   }
   environmentDestroy(&global_environment);
   arenaDestroy(temp_arena);
   arenaDestroy(ast_arena);
+  allocationProfileReport();
   return 0;
 }
 

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -1,4 +1,5 @@
 #include "../lib/arena.h"
+#include "../lib/profile.h"
 #include "../lifp/environment.h"
 #include "../lifp/evaluate.h"
 #include "../lifp/fmt.h"
@@ -6,11 +7,10 @@
 #include "../lifp/parse.h"
 #include "../lifp/tokenize.h"
 #include "../vendor/linenoise/linenoise.h"
-#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 
-allocationProfileInit();
+allocMetricsInit();
 
 // Size of the output buffer
 constexpr size_t BUFFER_SIZE = 4096;
@@ -60,8 +60,7 @@ int main(void) {
 
   linenoiseSetMultiLine(1);
 
-  allocationProfileReport();
-
+  profileInit();
   while (true) {
     arenaReset(ast_arena);
     arenaReset(temp_arena);
@@ -92,12 +91,12 @@ int main(void) {
     printf("~> %s\n", buffer);
 
     memset(buffer, 0, BUFFER_SIZE);
-    allocationProfileReport();
+    profileReport();
   }
+  profileEnd();
   environmentDestroy(&global_environment);
   arenaDestroy(temp_arena);
   arenaDestroy(ast_arena);
-  allocationProfileReport();
   return 0;
 }
 

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -62,6 +62,7 @@ int main(void) {
 
   profileInit();
   while (true) {
+    profileReport();
     arenaReset(ast_arena);
     arenaReset(temp_arena);
     char *input = linenoise("> ");
@@ -91,7 +92,6 @@ int main(void) {
     printf("~> %s\n", buffer);
 
     memset(buffer, 0, BUFFER_SIZE);
-    profileReport();
   }
   profileEnd();
   environmentDestroy(&global_environment);

--- a/bin/run.c
+++ b/bin/run.c
@@ -143,8 +143,9 @@ int main(int argc, char **argv) {
     tryRun(evaluate(temp_arena, syntax_tree, global_environment), reduced);
   } while (strlen(line_buffer) > 0);
 
-  arenaDestroy(ast_arena);
   environmentDestroy(&global_environment);
+  arenaDestroy(&temp_arena);
+  arenaDestroy(&ast_arena);
   return 0;
 }
 

--- a/docs/profilers.md
+++ b/docs/profilers.md
@@ -43,7 +43,7 @@ Available profilers in this project are:
 * `safeAlloc`: track usage of the `safeAlloc` function to detect leaks;
 * `arena`: track arena allocation and report stats on arena usage;
 
-You can read more about them in [`profile.h`](..lib/profile.h).
+You can read more about them in [`profile.h`](../lib/profile.h).
 
 ## Off-the-shelf profilers
 

--- a/docs/profilers.md
+++ b/docs/profilers.md
@@ -1,0 +1,54 @@
+Profilers
+---
+
+This project hosts some profilers to ensure we can have a good handle of what
+happens at any point in time and optimize/debug issues accordingly.
+
+## Guidelines
+
+Profilers must be designed to be compiled away when not needed. They have to be
+guarded with `#ifdef` clauses such that, when the build does not require so, no
+symbols nor memory is used by compilers.
+
+References:
+  - [`profile.h`](../lib/profile.h) for a reference profiler;
+  - [`Makefile`](../Makefile) to allow turning on your profiler with PROFILE=1;
+
+## Span-based Profiling
+
+Profiling is done using a span-based approach. A span is a code section enclosed
+by calls to `...SpanStart` and `...SpanEnd`. There are different start and end
+functions depending on the type of profiling you need.
+
+Typically, a span is a function. Macros making use of the [`cleanup`
+attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html)
+ease instrumentation of a function with just one intruction at the beginning of
+the function body.
+
+For example,
+```c
+#include "lib/profile.h"
+
+void myFunction() {
+    profileSafeAlloc();  // Enable safeAlloc profiling for this function
+
+    // ...rest of the code
+}
+```
+
+## Available profilers
+
+Available profilers in this project are:
+
+* `safeAlloc`: track usage of the `safeAlloc` function to detect leaks;
+* `arena`: track arena allocation and report stats on arena usage;
+
+You can read more about them in [`profile.h`](..lib/profile.h).
+
+## Off-the-shelf profilers
+
+For more coarse profiling and bug detection, we make use of Address Sanitizer.
+
+The debug flags can be consulted in [`flags.mk`](../flags.mk).
+
+; vim: tw=80 cc=+1

--- a/flags.mk
+++ b/flags.mk
@@ -3,7 +3,7 @@
 ### A minimalistic C23 flags.mk with strict flags.
 ### 
 ### ```sh
-### make main               			# debug build (default)
+### make main               		# debug build (default)
 ### make BUILD_TYPE=debug main  	# debug build
 ### make BUILD_TYPE=release main	# release build
 ### ```

--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -12,37 +12,37 @@ typedef struct {
   void *pointers[MAX_SEGMENTS];
   size_t sizes[MAX_SEGMENTS];
   bool freed[MAX_SEGMENTS];
-} alloc_metrics_t;
+} safe_alloc_metrics_t;
 
-extern alloc_metrics_t metrics;
-extern bool init;
+extern safe_alloc_metrics_t safe_alloc_metrics;
 
-#define allocProfileStart(Pointer, Size)                                         \
-  if (metrics.segments_count < MAX_SEGMENTS) {                                 \
-    metrics.pointers[metrics.segments_count] = Pointer;                        \
-    metrics.sizes[metrics.segments_count] = Size;                              \
-    metrics.freed[metrics.segments_count] = false;                             \
-    metrics.segments_count++;                                                  \
-    metrics.bytes += (Size);                                                   \
+#define allocProfileStart(Pointer, Size)                                       \
+  if (safe_alloc_metrics.segments_count < MAX_SEGMENTS) {                      \
+    safe_alloc_metrics.pointers[safe_alloc_metrics.segments_count] = Pointer;  \
+    safe_alloc_metrics.sizes[safe_alloc_metrics.segments_count] = Size;        \
+    safe_alloc_metrics.freed[safe_alloc_metrics.segments_count] = false;       \
+    safe_alloc_metrics.segments_count++;                                       \
+    safe_alloc_metrics.bytes += (Size);                                        \
   }
 
-#define allocProfileEnd(DoublePointer)                                           \
-  for (unsigned long i = 0; i < metrics.segments_count; i++) {                 \
-    if (*(DoublePointer) == metrics.pointers[i] && !metrics.freed[i]) {        \
-      metrics.bytes -= metrics.sizes[i];                                       \
-      metrics.freed[i] = true;                                                 \
+#define allocProfileEnd(DoublePointer)                                         \
+  for (unsigned long i = 0; i < safe_alloc_metrics.segments_count; i++) {      \
+    if (*(DoublePointer) == safe_alloc_metrics.pointers[i] &&                  \
+        !safe_alloc_metrics.freed[i]) {                                        \
+      safe_alloc_metrics.bytes -= safe_alloc_metrics.sizes[i];                 \
+      safe_alloc_metrics.freed[i] = true;                                      \
     }                                                                          \
   }
 
-#define allocGetMetrics() metrics
+#define allocGetMetrics() safe_alloc_metrics
 
-#define allocMetricsInit() alloc_metrics_t metrics = {}
+#define allocMetricsInit() safe_alloc_metrics_t safe_alloc_metrics = {}
 
 #else
 
 #define allocProfileStart(Pointer, Size)
 #define allocProfileEnd(DoublePointer)
-#define allocProfileGetMetrics()
+#define allocGetMetrics()
 #define allocMetricsInit()
 
 #endif

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -29,6 +29,8 @@ result_ref_t arenaAllocate(arena_t *self, size_t size) {
   return ok(result_ref_t, pointer);
 }
 
-void arenaDestroy(arena_t *self) { deallocSafe(&self); }
+void arenaDestroy(arena_t **self) {
+  arenaProfileEnd(*self);
+}
 
 void arenaReset(arena_t *self) { self->offset = 0; }

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -5,17 +5,43 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef MEMORY_PROFILE
+arena_metrics_t arena_metrics = {};
+
+#define arenaProfileStart(Arena)                                               \
+  arena_metrics.arenas[arena_metrics.arenas_count] = Arena;                    \
+  arena_metrics.freed[arena_metrics.arenas_count] = false;                     \
+  arena_metrics.arenas_count++;
+
+#define arenaProfileEnd(Arena)                                                 \
+  for (size_t i = 0; i < arena_metrics.arenas_count; i++) {                    \
+    if (arena_metrics.arenas[i] == Arena) {                                    \
+      arena_metrics.freed[i] = true;                                           \
+      break;                                                                   \
+    }                                                                          \
+  }
+
+#else
+
+#define arenaProfileStart(Arena)
+#define arenaProfileEnd(Arena)
+
+#endif
+
 result_ref_t arenaCreate(size_t size) {
   arena_t *arena = nullptr;
   try(result_ref_t, allocSafe(sizeof(arena_t) + size), arena);
   arena->size = size;
   arena->offset = 0;
+
+  arenaProfileStart(arena);
+
   return ok(result_ref_t, arena);
 }
 
 result_ref_t arenaAllocate(arena_t *self, size_t size) {
-  size_t aligned_offset = (self->offset + 7U) & ~7U;
-  size_t aligned_size = (size + 7U) & ~7U;
+  const size_t aligned_offset = (self->offset + 7U) & ~7U;
+  const size_t aligned_size = (size + 7U) & ~7U;
 
   if (aligned_offset + aligned_size > self->size) {
     throw(result_ref_t, ARENA_ERROR_OUT_OF_SPACE, nullptr,
@@ -31,6 +57,7 @@ result_ref_t arenaAllocate(arena_t *self, size_t size) {
 
 void arenaDestroy(arena_t **self) {
   arenaProfileEnd(*self);
+  deallocSafe(self);
 }
 
 void arenaReset(arena_t *self) { self->offset = 0; }

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -38,7 +38,6 @@
 #pragma once
 
 #include "alloc.h"
-#include <stdlib.h>
 
 typedef unsigned char byte_t;
 typedef char message_t[64];

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -96,7 +96,7 @@ result_ref_t arenaAllocate(arena_t *self, size_t size);
  * @example
  *   arenaDestroy(arena);  // arena pointer becomes invalid
  */
-void arenaDestroy(arena_t *self);
+void arenaDestroy(arena_t **self);
 
 /**
  * Reset the arena to empty state.

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -57,6 +57,18 @@ typedef struct {
   byte_t memory[]; // Flexible array member containing the actual memory buffer
 } arena_t;
 
+#ifdef MEMORY_PROFILE
+constexpr size_t MAX_PROFILED_ARENAS = 128;
+
+typedef struct {
+  arena_t *arenas[MAX_PROFILED_ARENAS];
+  bool freed[MAX_PROFILED_ARENAS];
+  size_t arenas_count;
+} arena_metrics_t;
+
+extern arena_metrics_t arena_metrics;
+#endif
+
 /**
  * Create a new arena with the specified size.
  * @name arenaCreate

--- a/lib/list.h
+++ b/lib/list.h
@@ -28,7 +28,7 @@
 //         }
 //     }
 //
-//     arenaDestroy(arena);
+//     arenaDestroy(&arena);
 // }
 // ```
 

--- a/lib/map.h
+++ b/lib/map.h
@@ -29,7 +29,7 @@
 //         }
 //     }
 //
-//     arenaDestroy(arena);
+//     arenaDestroy(&arena);
 // }
 // ```
 

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -1,30 +1,20 @@
 #include "profile.h"
-#include "arena.h"
-#include "memory.h"
-#include "result.h"
+
+#ifdef MEMORY_PROFILE
+
+#include "alloc.h"
 #include <assert.h>
-#include <mach/mach.h>
-#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/resource.h>
 
-// Global span variables
 span_t *CURRENT_SPAN = nullptr;
 span_t *ROOT_SPAN = nullptr;
 
-static long getCurrentMemory(void) {
-  struct mach_task_basic_info info;
-  mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
-  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info,
-                &info_count) != KERN_SUCCESS)
-    return 0;
-  return (long)info.resident_size; // in bytes
-}
+static unsigned long getCurrentMemory(void) { return allocGetMetrics().bytes; }
 
 static unsigned long hash(const char *key) {
+  static constexpr unsigned long prime = 1099511628211U;
   unsigned long hash = 14695981039346656037U;
-  const unsigned long prime = 1099511628211U;
   const size_t len = strlen(key);
 
   for (size_t i = 0; i < len; i++) {
@@ -35,40 +25,53 @@ static unsigned long hash(const char *key) {
   return hash;
 }
 
-static result_ref_t spanCreate(arena_t *arena, const char *label) {
-  span_t *span;
-  try(result_ref_t, arenaAllocate(arena, sizeof(span_t)), span);
+static span_t *spanCreate(const char *label) {
+  span_t *span = malloc(sizeof(span_t));
   span->hits = 0;
   span->total = 0;
   span->last = 0;
-  span->arena = arena;
   span->label[0] = 0;
   span->subspans_count = 0;
   span->span_id = hash(label);
-  strncpy(span->label, label, strlen(label));
-  return ok(result_ref_t, span);
+
+  auto label_len = strlen(label);
+  label_len = label_len >= SPAN_LABEL_LEN ? SPAN_LABEL_LEN - 1 : label_len;
+  strncpy(span->label, label, label_len);
+  span->label[label_len] = 0;
+  return span;
 }
 
-result_void_t metricsInit(arena_t *arena) {
-  try(result_void_t, spanCreate(arena, "root"), CURRENT_SPAN);
+static void spanFree(span_t **span) {
+  if (*span == nullptr)
+    return;
+
+  for (unsigned long i = 0; i < (*span)->subspans_count; i++) {
+    spanFree(&(*span)->subspans[i]);
+  }
+  deallocSafe(span);
+}
+
+void profileInit() {
+  metrics.bytes = 0;
+  metrics.segments_count = 0;
+  CURRENT_SPAN = spanCreate("root");
   ROOT_SPAN = CURRENT_SPAN;
   ROOT_SPAN->hits = 1; // prevent division by zero
-  return ok(result_void_t);
 }
 
-result_ref_t metricsStart(const char *label) {
+span_t *spanStart(const char *label) {
   assert(CURRENT_SPAN);
-  unsigned long id = hash(label);
+  const unsigned long span_id = hash(label);
 
   span_t *span = nullptr;
-  for (long i = 0; i < CURRENT_SPAN->subspans_count; i++) {
-    if (CURRENT_SPAN->subspans[i]->span_id == id) {
+  for (unsigned long i = 0; i < CURRENT_SPAN->subspans_count; i++) {
+    if (CURRENT_SPAN->subspans[i]->span_id == span_id) {
       span = CURRENT_SPAN->subspans[i];
     }
   }
 
   if (!span) {
-    try(result_ref_t, spanCreate(CURRENT_SPAN->arena, label), span);
+    span = spanCreate(label);
     CURRENT_SPAN->subspans[CURRENT_SPAN->subspans_count] = span;
     CURRENT_SPAN->subspans_count++;
   }
@@ -77,12 +80,11 @@ result_ref_t metricsStart(const char *label) {
   span->last = getCurrentMemory();
   span->parent = CURRENT_SPAN;
   CURRENT_SPAN = span;
-
-  return ok(result_ref_t, span);
+  return span;
 }
 
-result_void_t metricsEnd(result_ref_t *span_ref) {
-  span_t *span = span_ref->value;
+void spanEnd(span_t **span_double_ref) {
+  span_t *span = *span_double_ref;
   span->total += getCurrentMemory() - span->last;
 
   if (span->parent) {
@@ -90,24 +92,29 @@ result_void_t metricsEnd(result_ref_t *span_ref) {
   }
 
   CURRENT_SPAN = span->parent;
-  return ok(result_void_t);
 }
 
 void printSpan(const span_t *span, int indentation) {
   char prefix[32];
   snprintf(prefix, 32, "%*c", indentation * 2, ' ');
 
-  printf("%s %s[%lu]: %lu bytes (%0.2f bytes)\n", prefix, span->label,
+  printf("%s %s[%lu]: %lu bytes (%0.2f bytes/hit)\n", prefix, span->label,
          span->hits, span->total, (double)span->total / (double)span->hits);
 
-  for (long i = 0; i < span->subspans_count; i++) {
+  for (unsigned long i = 0; i < span->subspans_count; i++) {
     printSpan(span->subspans[i], indentation + 1);
   }
 }
 
-void metricsReport(void) {
+void profileReport(void) {
   assert(CURRENT_SPAN);
 
-  printf(" === Memory Metrics ===\n");
+  printf(" === Memory Metrics: Leaked safeAlloc ===\n");
   printSpan(ROOT_SPAN, 0);
 }
+
+void profileEnd(void) {
+  spanFree(&ROOT_SPAN);
+  CURRENT_SPAN = nullptr;
+}
+#endif

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -85,10 +85,11 @@ span_t *spanStart(const char *label) {
 
 void spanEnd(span_t **span_double_ref) {
   span_t *span = *span_double_ref;
-  span->total += getCurrentMemory() - span->last;
+  unsigned long delta = getCurrentMemory() - span->last;
+  span->total += delta;
 
   if (span->parent) {
-    span->parent->total += span->total;
+    span->parent->total += delta;
   }
 
   CURRENT_SPAN = span->parent;

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -72,8 +72,13 @@ span_t *spanStart(const char *label) {
 
   if (!span) {
     span = spanCreate(label);
-    CURRENT_SPAN->subspans[CURRENT_SPAN->subspans_count] = span;
-    CURRENT_SPAN->subspans_count++;
+    if (CURRENT_SPAN->subspans_count < MAX_SUBSPAN) {
+      CURRENT_SPAN->subspans[CURRENT_SPAN->subspans_count] = span;
+      CURRENT_SPAN->subspans_count++;
+    } else {
+      printf("cannot allocate new profiling span\n");
+      return nullptr;
+    }
   }
 
   span->hits++;

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -166,14 +166,23 @@ void printSpan(const span_t *span, int indentation) {
 }
 
 void printArenas(void) {
+  size_t freed = 0;
   for (size_t i = 0; i < arena_metrics.arenas_count; i++) {
     arena_t *arena = arena_metrics.arenas[i];
-    if (!arena_metrics.freed[i]) {
-      printf("   arena[%lu]: %lu/%lu bytes (%0.2f%%)\n", i, arena->offset,
+    if (arena_metrics.freed[i]) {
+      freed++;
+    } else {
+      printf("    arena[%lu]: %lu/%lu bytes (%0.2f%%)\n", i, arena->offset,
              arena->size,
              (double)(arena->offset * 100) / (double)(arena->size));
     }
   }
+
+  printf("\n"
+         "    Stats:\n"
+         "      tracked:   %lu arenas\n"
+         "      destroyed: %lu arenas\n",
+         arena_metrics.arenas_count, freed);
 }
 
 void profileReport(void) {

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -119,7 +119,7 @@ span_t *arenaSpanStart(arena_t *arena, const char *label) {
       CURRENT_ARENA_SPAN->subspans_count++;
     } else {
       printf("Profiling error: Maximum subspans (%lu) reached for span '%s'\n",
-             MAX_SUBSPAN, CURRENT_SAFE_ALLOC_SPAN->label);
+             MAX_SUBSPAN, CURRENT_ARENA_SPAN->label);
       return nullptr;
     }
   }

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -86,7 +86,8 @@ span_t *safeAllocSpanStart(const char *label) {
           ->subspans[CURRENT_SAFE_ALLOC_SPAN->subspans_count] = span;
       CURRENT_SAFE_ALLOC_SPAN->subspans_count++;
     } else {
-      printf("cannot allocate new profiling span\n");
+      printf("Profiling error: Maximum subspans (%lu) reached for span '%s'\n",
+             MAX_SUBSPAN, CURRENT_SAFE_ALLOC_SPAN->label);
       return nullptr;
     }
   }
@@ -115,7 +116,8 @@ span_t *arenaSpanStart(arena_t *arena, const char *label) {
       CURRENT_ARENA_SPAN->subspans[CURRENT_ARENA_SPAN->subspans_count] = span;
       CURRENT_ARENA_SPAN->subspans_count++;
     } else {
-      printf("cannot allocate new profiling span\n");
+      printf("Profiling error: Maximum subspans (%lu) reached for span '%s'\n",
+             MAX_SUBSPAN, CURRENT_SAFE_ALLOC_SPAN->label);
       return nullptr;
     }
   }

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -1,0 +1,113 @@
+#include "profile.h"
+#include "arena.h"
+#include "memory.h"
+#include "result.h"
+#include <assert.h>
+#include <mach/mach.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+
+// Global span variables
+span_t *CURRENT_SPAN = nullptr;
+span_t *ROOT_SPAN = nullptr;
+
+static long getCurrentMemory(void) {
+  struct mach_task_basic_info info;
+  mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info,
+                &info_count) != KERN_SUCCESS)
+    return 0;
+  return (long)info.resident_size; // in bytes
+}
+
+static unsigned long hash(const char *key) {
+  unsigned long hash = 14695981039346656037U;
+  const unsigned long prime = 1099511628211U;
+  const size_t len = strlen(key);
+
+  for (size_t i = 0; i < len; i++) {
+    hash ^= (unsigned long)(unsigned char)key[i];
+    hash *= prime;
+  }
+
+  return hash;
+}
+
+static result_ref_t spanCreate(arena_t *arena, const char *label) {
+  span_t *span;
+  try(result_ref_t, arenaAllocate(arena, sizeof(span_t)), span);
+  span->hits = 0;
+  span->total = 0;
+  span->last = 0;
+  span->arena = arena;
+  span->label[0] = 0;
+  span->subspans_count = 0;
+  span->span_id = hash(label);
+  strncpy(span->label, label, strlen(label));
+  return ok(result_ref_t, span);
+}
+
+result_void_t metricsInit(arena_t *arena) {
+  try(result_void_t, spanCreate(arena, "root"), CURRENT_SPAN);
+  ROOT_SPAN = CURRENT_SPAN;
+  ROOT_SPAN->hits = 1; // prevent division by zero
+  return ok(result_void_t);
+}
+
+result_ref_t metricsStart(const char *label) {
+  assert(CURRENT_SPAN);
+  unsigned long id = hash(label);
+
+  span_t *span = nullptr;
+  for (long i = 0; i < CURRENT_SPAN->subspans_count; i++) {
+    if (CURRENT_SPAN->subspans[i]->span_id == id) {
+      span = CURRENT_SPAN->subspans[i];
+    }
+  }
+
+  if (!span) {
+    try(result_ref_t, spanCreate(CURRENT_SPAN->arena, label), span);
+    CURRENT_SPAN->subspans[CURRENT_SPAN->subspans_count] = span;
+    CURRENT_SPAN->subspans_count++;
+  }
+
+  span->hits++;
+  span->last = getCurrentMemory();
+  span->parent = CURRENT_SPAN;
+  CURRENT_SPAN = span;
+
+  return ok(result_ref_t, span);
+}
+
+result_void_t metricsEnd(result_ref_t *span_ref) {
+  span_t *span = span_ref->value;
+  span->total += getCurrentMemory() - span->last;
+
+  if (span->parent) {
+    span->parent->total += span->total;
+  }
+
+  CURRENT_SPAN = span->parent;
+  return ok(result_void_t);
+}
+
+void printSpan(const span_t *span, int indentation) {
+  char prefix[32];
+  snprintf(prefix, 32, "%*c", indentation * 2, ' ');
+
+  printf("%s %s[%lu]: %lu bytes (%0.2f bytes)\n", prefix, span->label,
+         span->hits, span->total, (double)span->total / (double)span->hits);
+
+  for (long i = 0; i < span->subspans_count; i++) {
+    printSpan(span->subspans[i], indentation + 1);
+  }
+}
+
+void metricsReport(void) {
+  assert(CURRENT_SPAN);
+
+  printf(" === Memory Metrics ===\n");
+  printSpan(ROOT_SPAN, 0);
+}

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "arena.h"
+#include "result.h"
+#include <stddef.h>
+
+constexpr size_t MAX_SUBSPAN = 16;
+
+typedef struct span_t {
+  char label[16];
+  long hits;
+  long total;
+  long last;
+  long subspans_count;
+  unsigned long span_id;
+  arena_t *arena;
+  struct span_t *parent;
+  struct span_t *subspans[MAX_SUBSPAN];
+} span_t;
+
+result_void_t metricsInit(arena_t *arena);
+result_ref_t metricsStart(const char *label);
+result_void_t metricsEnd(result_ref_t *span_ref);
+void metricsReport(void);
+
+#define profile                                                                \
+  result_ref_t _concat(metrics_, __LINE__)                                     \
+      __attribute__((cleanup(metricsEnd))) = metricsStart(__FUNCTION__);

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -1,5 +1,49 @@
 #pragma once
 
+// Profile (v0.0.1)
+//
+// Span-based memory profilers to catch leaks and track allocations.
+//
+// !!! All profilers must be able to be compiled away with a flag !!!
+//
+// In this case, the flag is `MEMORY_PROFILE`.
+//
+// There are two profilers here: `safeAlloc` and `arena`.
+//
+// `safeAlloc` tracks the usage of the `safeAlloc` util, which we use
+// to allocate memory instead of barebone `malloc`/`free`. It tracks
+// allocations by diffing the safeAlloc-ed memory at the beginning and
+// at the end of the span.
+//
+// ```c
+// void myFunction() {
+//   // Profile the whole function
+//   profileSafeAlloc();
+//
+//   // Profile a specific section
+//   span_t *span = safeAllocSpanStart("label");
+//     // profiled code
+//   safeAllocSpanEnd(&span);
+// }
+// ```
+//
+// `arena` tracks arena utilization. Arenas by definition cannot leak,
+// so this profiler is just there to see where memory gets allocated.
+// Tracking is done by checking the arena offset across the span
+//
+// ```c
+// void myFunction(arena_t *arena) {
+//   // Profile the whole function
+//   profileArena(arena);
+//
+//   // Profile a specific section
+//   span_t span = arenaSpanStart(arena, "label");
+//     // profiled code
+//   arenaSpanEnd(&span);
+// }
+// ```
+//
+
 #ifdef MEMORY_PROFILE
 #include "arena.h"
 #include "result.h"

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -1,28 +1,38 @@
 #pragma once
 
-#include "arena.h"
+#ifdef MEMORY_PROFILE
 #include "result.h"
-#include <stddef.h>
 
 constexpr size_t MAX_SUBSPAN = 16;
+constexpr size_t SPAN_LABEL_LEN = 16;
 
 typedef struct span_t {
-  char label[16];
-  long hits;
-  long total;
-  long last;
-  long subspans_count;
+  char label[SPAN_LABEL_LEN];
+  unsigned long hits;
+  unsigned long total;
+  unsigned long last;
+  unsigned long subspans_count;
   unsigned long span_id;
-  arena_t *arena;
   struct span_t *parent;
   struct span_t *subspans[MAX_SUBSPAN];
 } span_t;
 
-result_void_t metricsInit(arena_t *arena);
-result_ref_t metricsStart(const char *label);
-result_void_t metricsEnd(result_ref_t *span_ref);
-void metricsReport(void);
+void profileInit(void);
+void profileReport(void);
+void profileEnd(void);
 
-#define profile                                                                \
-  result_ref_t _concat(metrics_, __LINE__)                                     \
-      __attribute__((cleanup(metricsEnd))) = metricsStart(__FUNCTION__);
+span_t *spanStart(const char *label);
+void spanEnd(span_t **span_double_ref);
+
+#define profileAllocations()                                                   \
+  span_t *_concat(metrics_, __LINE__) __attribute__((cleanup(spanEnd))) =      \
+      spanStart(__FUNCTION__);
+
+#else
+
+#define profileAllocations()
+#define profileReport()
+#define profileInit(Arena)
+#define profileEnd()
+
+#endif

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifdef MEMORY_PROFILE
+#include "arena.h"
 #include "result.h"
 
 constexpr size_t MAX_SUBSPAN = 16;
@@ -9,30 +10,40 @@ constexpr size_t SPAN_LABEL_LEN = 16;
 typedef struct span_t {
   char label[SPAN_LABEL_LEN];
   unsigned long hits;
-  unsigned long total;
   unsigned long last;
+  unsigned long total;
   unsigned long subspans_count;
   unsigned long span_id;
   struct span_t *parent;
   struct span_t *subspans[MAX_SUBSPAN];
+  void *payload;
 } span_t;
 
 void profileInit(void);
 void profileReport(void);
 void profileEnd(void);
 
-span_t *spanStart(const char *label);
-void spanEnd(span_t **span_double_ref);
+span_t *safeAllocSpanStart(const char *label);
+void safeAllocSpanEnd(span_t **span_double_ref);
+span_t *arenaSpanStart(arena_t *arena, const char *label);
+void arenaSpanEnd(span_t **span_double_ref);
 
-#define profileAllocations()                                                   \
-  span_t *_concat(metrics_, __LINE__) __attribute__((cleanup(spanEnd))) =      \
-      spanStart(__FUNCTION__);
+#define profileSafeAlloc()                                                     \
+  span_t *_concat(metrics_, __LINE__)                                          \
+      __attribute__((cleanup(safeAllocSpanEnd))) =                             \
+          safeAllocSpanStart(__FUNCTION__);
+
+#define profileArena(Arena)                                                    \
+  span_t *_concat(metrics_, __LINE__) __attribute__((cleanup(arenaSpanEnd))) = \
+      arenaSpanStart(Arena, __FUNCTION__);
 
 #else
 
-#define profileAllocations()
 #define profileReport()
-#define profileInit(Arena)
+#define profileInit()
 #define profileEnd()
+
+#define profileSafeAlloc()
+#define profileArena(Arena)
 
 #endif

--- a/lib/profile.h
+++ b/lib/profile.h
@@ -43,6 +43,11 @@ void arenaSpanEnd(span_t **span_double_ref);
 #define profileInit()
 #define profileEnd()
 
+#define safeAllocSpanStart(Label)
+#define safeAllocSpanEnd(Span)
+#define arenaSpanStart(Arena, Label)
+#define arenaSpanEnd(Span)
+
 #define profileSafeAlloc()
 #define profileArena(Arena)
 

--- a/lifp/environment.c
+++ b/lifp/environment.c
@@ -60,8 +60,9 @@ result_ref_t environmentCreate(environment_t *parent) {
 
 void environmentDestroy(environment_t **self) {
   assert(self && *self);
+  arena_t *arena = (*self)->arena;
   // The environment is allocated on its own arena. This frees all the resources
-  arenaDestroy((*self)->arena);
+  arenaDestroy(&arena);
   // Setting the reference to null for good measure
   *(self) = nullptr;
 }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -1,4 +1,5 @@
 #include "evaluate.h"
+#include "../lib/profile.h"
 #include "environment.h"
 #include "error.h"
 #include "node.h"
@@ -47,6 +48,8 @@ static result_value_ref_t invokeBuiltin(value_t *result, value_t builtin_value,
 static result_value_ref_t invokeClosure(value_t *result, value_t closure_value,
                                         arena_t *arena,
                                         environment_t *parent_environment) {
+  profileAllocations();
+
   assert(closure_value.type == VALUE_TYPE_CLOSURE);
   closure_t closure = closure_value.value.closure;
 
@@ -134,6 +137,8 @@ result_value_ref_t evaluateList(arena_t *arena, node_t *syntax_tree,
 
 result_value_ref_t evaluate(arena_t *arena, node_t *syntax_tree,
                             environment_t *environment) {
+  profileAllocations();
+
   value_t *value = nullptr;
   tryWithMeta(result_value_ref_t, valueCreate(arena, VALUE_TYPE_INTEGER),
               syntax_tree->position, value);

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -48,7 +48,7 @@ static result_value_ref_t invokeBuiltin(value_t *result, value_t builtin_value,
 static result_value_ref_t invokeClosure(value_t *result, value_t closure_value,
                                         arena_t *arena,
                                         environment_t *parent_environment) {
-  profileAllocations();
+  profileSafeAlloc();
 
   assert(closure_value.type == VALUE_TYPE_CLOSURE);
   closure_t closure = closure_value.value.closure;
@@ -137,7 +137,8 @@ result_value_ref_t evaluateList(arena_t *arena, node_t *syntax_tree,
 
 result_value_ref_t evaluate(arena_t *arena, node_t *syntax_tree,
                             environment_t *environment) {
-  profileAllocations();
+  profileSafeAlloc();
+  profileArena(arena);
 
   value_t *value = nullptr;
   tryWithMeta(result_value_ref_t, valueCreate(arena, VALUE_TYPE_INTEGER),

--- a/lifp/fmt.c
+++ b/lifp/fmt.c
@@ -16,14 +16,14 @@
 static void formatCurrentLine(position_t caret, const char *input_buffer,
                               int size, char output_buffer[static size],
                               int *offset) {
-  const char *sepatator = "\n";
+  const char *separator = "\n";
   char *brkt = nullptr;
   char *line = nullptr;
   char *copy = strdup(input_buffer);
   size_t current_line = 1;
 
-  for (line = strtok_r(copy, sepatator, &brkt); line;
-       line = strtok_r(nullptr, sepatator, &brkt)) {
+  for (line = strtok_r(copy, separator, &brkt); line;
+       line = strtok_r(nullptr, separator, &brkt)) {
     if (caret.line == current_line)
       break;
   }
@@ -142,9 +142,7 @@ void formatValue(const value_t *value, int size,
 
     formatNode(&value->value.closure.form, size, output_buffer, offset);
     append(size, output_buffer, offset, ")");
-    return;
   default:
-    return;
   }
 }
 

--- a/tests/arena.test.c
+++ b/tests/arena.test.c
@@ -21,7 +21,7 @@ void basic() {
   result_ref_t reallocation = arenaAllocate(arena, 1024);
   expectTrue(reallocation.code == 0, "can reallocate memory after a reset");
   
-  arenaDestroy(arena);
+  arenaDestroy(&arena);
 }
 
 void overflow() {
@@ -34,7 +34,7 @@ void overflow() {
   expectFalse(allocation.code == 0, "fails oversized allocation");
   expectEqlString(allocation.message, "Arena out of memory. Available 100, requested 200", 64, "throws correct exception");
   
-  arenaDestroy(arena);
+  arenaDestroy(&arena);
 }
 
 void alignment() {
@@ -49,7 +49,7 @@ void alignment() {
     expectEqlUint(pointer % 8, 0, "address is 8-aligned");
   }
 
-  arenaDestroy(arena);
+  arenaDestroy(&arena);
 }
 
 int main() {

--- a/tests/evaluate.test.c
+++ b/tests/evaluate.test.c
@@ -171,7 +171,7 @@ void allocations() {
   expectEqlInt(reduction.code, ERROR_CODE_ALLOCATION,
                 "returns allocation error");
 
-  arenaDestroy(small_arena);
+  arenaDestroy(&small_arena);
 }
 
 void errors() {
@@ -424,6 +424,6 @@ int main(void) {
   suite(condSpecialForm);
 
   environmentDestroy(&environment);
-  arenaDestroy(test_arena);
+  arenaDestroy(&test_arena);
   return report();
 }

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -76,7 +76,7 @@ int main() {
   reduction = execute("(def! sum (fn (a b) (+ a b)))\n(sum 1 2)");
   expectEqlInt(reduction.value->value.integer, 3, "returns correct value");
 
-  arenaDestroy(test_ast_arena);
-  arenaDestroy(test_temp_arena);
+  arenaDestroy(&test_ast_arena);
+  arenaDestroy(&test_temp_arena);
   return report();
 }

--- a/tests/list.test.c
+++ b/tests/list.test.c
@@ -52,6 +52,6 @@ int main(void) {
   result = listCopy(int, list, different);
   expectEqlInt(result.code, LIST_ERROR_INCOMPATIBLE_LISTS, "throws error");
 
-  arenaDestroy(test_arena);
+  arenaDestroy(&test_arena);
   return report();
 }

--- a/tests/map.test.c
+++ b/tests/map.test.c
@@ -115,6 +115,6 @@ int main() {
   suite(getSet);
   suite(allocations);
 
-  arenaDestroy(test_arena);
+  arenaDestroy(&test_arena);
   return report();
 }

--- a/tests/parser.test.c
+++ b/tests/parser.test.c
@@ -209,6 +209,6 @@ int main(void) {
   suite(unary);
   suite(complex);
   suite(errors);
-  arenaDestroy(test_arena);
+  arenaDestroy(&test_arena);
   return report();
 }

--- a/tests/tokenize.test.c
+++ b/tests/tokenize.test.c
@@ -169,6 +169,6 @@ int main(void) {
   suite(whitespaces);
   suite(errors);
 
-  arenaDestroy(test_arena);
+  arenaDestroy(&test_arena);
   return report();
 }


### PR DESCRIPTION
This change introduces two memory profilers

* Malloc Memory Profiler
* Arena Memory Profiler

The former helps identifying how the memory is malloc-ed down to the byte level. We're not using `getrusage` because that would not be useful to identify if we are accidentally over- allocating. It might be useful to see how much memory the system allocates to the lifp process, but that's out of scope now.

The latter tracks every time an allocation in an Arena occurs and helps visualizing who is allocating what in the arena.

They are both span based, with the minimum span being a function.

They are both transparent: you only get the profilers code when you make with PROFILE=1. 
The instrumentation can live in the code without any overhead.

----

## AI blurb

This pull request introduces a memory profiling system for both safe allocations and arena allocations, along with related code changes to enable and track profiling metrics. It adds conditional compilation for profiling, new metrics structures, and span-based profiling utilities. Additionally, several APIs and tests are updated to support the new profiling features and ensure proper tracking and destruction of memory resources.

### Memory Profiling Infrastructure

* Added a conditional `MEMORY_PROFILE` mode in the `Makefile` and codebase, enabling extra tracking logic and metrics structures for allocations and arenas. (`Makefile`, `lib/alloc.h`, `lib/arena.h`, `lib/profile.h`, `lib/profile.c`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R3-R6) [[2]](diffhunk://#diff-5eca8547df08f1b1309944c17f74eedf241d5ed72a888fab8bec0e56883d0f87L4-R55) [[3]](diffhunk://#diff-448674ee492e9e82be199d67344567ed07e21cf1946e02c3c0d2864116c2c932R60-R71) [[4]](diffhunk://#diff-1233f9fd5b7923eb9002797084aba4fd5d12f82eb84718cb5df2a91e5315deb0R1-R49) [[5]](diffhunk://#diff-09e7351f8453cc7bdc3e6a65346a5969a5ab1343b84069a6fe94b4c089d3e6f7R1-R209)
* Implemented span-based profiling utilities for both safe allocations and arenas, including functions for starting/ending spans, reporting, and cleanup. (`lib/profile.h`, `lib/profile.c`) [[1]](diffhunk://#diff-1233f9fd5b7923eb9002797084aba4fd5d12f82eb84718cb5df2a91e5315deb0R1-R49) [[2]](diffhunk://#diff-09e7351f8453cc7bdc3e6a65346a5969a5ab1343b84069a6fe94b4c089d3e6f7R1-R209)

### Allocation and Arena API Changes

* Updated allocation and deallocation macros to record profiling metrics when enabled, including tracking allocated pointers, sizes, and freed status. (`lib/alloc.h`) [[1]](diffhunk://#diff-5eca8547df08f1b1309944c17f74eedf241d5ed72a888fab8bec0e56883d0f87L4-R55) [[2]](diffhunk://#diff-5eca8547df08f1b1309944c17f74eedf241d5ed72a888fab8bec0e56883d0f87R100-R101) [[3]](diffhunk://#diff-5eca8547df08f1b1309944c17f74eedf241d5ed72a888fab8bec0e56883d0f87R116)
* Changed `arenaDestroy` to take a double pointer and track destruction in profiling metrics, and updated all usages and documentation accordingly. (`lib/arena.c`, `lib/arena.h`, `lifp/environment.c`, `lib/list.h`, `lib/map.h`, `tests/arena.test.c`, `tests/evaluate.test.c`) [[1]](diffhunk://#diff-eba83264d09f1dc16365ae9b1f4c7c24a6ee9c19259613573601c4ed75c4f60aL32-R61) [[2]](diffhunk://#diff-448674ee492e9e82be199d67344567ed07e21cf1946e02c3c0d2864116c2c932L100-R111) [[3]](diffhunk://#diff-b24d4c5bb4e4a1157500a05f32b1cf0d718af9e8c86d540ecb17a2cc2ca62127R63-R65) [[4]](diffhunk://#diff-decf32f12f34cb392f4cba3ab3394c7a7a2a274c5cd11a54c0b342ba3e29998aL31-R31) [[5]](diffhunk://#diff-7b6094e8dba1bdb1e9aab591875745dd042158750afdde11b9924f3a4709e509L32-R32) [[6]](diffhunk://#diff-bb85a451cdb6e5efe9410756862c9c3333f92413a9e69ce92475cdac0d671518L24-R24) [[7]](diffhunk://#diff-bb85a451cdb6e5efe9410756862c9c3333f92413a9e69ce92475cdac0d671518L37-R37) [[8]](diffhunk://#diff-bb85a451cdb6e5efe9410756862c9c3333f92413a9e69ce92475cdac0d671518L52-R52) [[9]](diffhunk://#diff-dd5824c7b652ed4ded717aa602a894ae3ad78cc5c8a0a9a71deb0dad9fe18a32L174-R174)

### Profiling Integration in Evaluation

* Integrated profiling macros (`profileSafeAlloc`, `profileArena`) into evaluation logic to track memory usage during evaluation and closure invocation. (`lifp/evaluate.c`) [[1]](diffhunk://#diff-ceb4e181b0337faef2aab27324ea75885dd7fe6ca0eb69a5059f419a49fd1b78R2) [[2]](diffhunk://#diff-ceb4e181b0337faef2aab27324ea75885dd7fe6ca0eb69a5059f419a49fd1b78R51-R52) [[3]](diffhunk://#diff-ceb4e181b0337faef2aab27324ea75885dd7fe6ca0eb69a5059f419a49fd1b78R140-R142)

### Minor Fixes and Cleanups

* Fixed a typo in `lifp/fmt.c` (`sepatator` → `separator`) and cleaned up unreachable code in `formatValue`. [[1]](diffhunk://#diff-35353ebdcb006ff5add8feb352dcbeaa94fe77a0bf7b33df55b5061a015778e7L19-R26) [[2]](diffhunk://#diff-35353ebdcb006ff5add8feb352dcbeaa94fe77a0bf7b33df55b5061a015778e7L145-L147)
* Updated documentation and comments to reflect new profiling and API usage. [[1]](diffhunk://#diff-5eca8547df08f1b1309944c17f74eedf241d5ed72a888fab8bec0e56883d0f87L40-R88) [[2]](diffhunk://#diff-448674ee492e9e82be199d67344567ed07e21cf1946e02c3c0d2864116c2c932L41)

### Build System and Linking

* Ensured `lib/profile.o` is linked into the `bin/repl` target in the `Makefile` when profiling is enabled.

These changes collectively add robust memory profiling capabilities to the project, improve resource tracking, and update the codebase for safer and more informative memory management.
