### PR TITLE
Improve memory usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,12 @@ jobs:
         make CC="${{ matrix.cc }}" clean test
       env:
         UNAME_S: ${{ matrix.platform == 'linux' && 'Linux' || 'Darwin' }}
+    
+    - name: Run tests (release)
+      run: |
+        make CC="${{ matrix.cc }}" BUILD_TYPE=release clean test
+      env:
+        UNAME_S: ${{ matrix.platform == 'linux' && 'Linux' || 'Darwin' }}
 
     - name: Build binary
       run: |

--- a/.todo
+++ b/.todo
@@ -32,8 +32,6 @@ REFACTORING
   * [ ] Special forms should live in the environment like values and closures
   * [ ] Make list methods (and hashmap methods) typesafe (now you can (append
        `node_t` to a `value_list_t` without errors)
-  * [ ] Value and Node allocations are pessimistic: we always assume it's a list
-       (worse case scenario) to shield the consumer from the allocation concerns.
   * [ ] Use [`libuv`](https://libuv.org) for non-blocking io
   * [ ] Std should be instantiated only once and pointed around instead of being cloned
   * [ ] Some structs are huge: mostly because we try to colocate most things. Do we need all of that?

--- a/.todo
+++ b/.todo
@@ -3,6 +3,8 @@ BUGS
   * [ ] `listGet` allows you to go out of bound
   * [ ] When `def!` reallocates the same symbol, it leaks memory (old symbol is not evicted)
   * [ ] `def!` does not return nil when compiled in release mode
+  * [ ] special forms are not recognised (type `def!` alone in repl and get error)
+  * [ ] defining `fact` from example returns false instead of null
 
 FEATURES
 ---
@@ -32,6 +34,7 @@ REFACTORING
        (worse case scenario) to shield the consumer from the allocation concerns.
   * [ ] Use [`libuv`](https://libuv.org) for non-blocking io
   * [ ] Std should be instantiated only once and pointed around instead of being cloned
+  * [ ] Some structs are huge: mostly because we try to colocate most things. Do we need all of that?
 
 OPEN STUFF
 ---

--- a/.todo
+++ b/.todo
@@ -24,6 +24,7 @@ FEATURES
   * [ ] Tail call optimization
   * [ ] Lexer should know about comments (and discard them)
   * [ ] Auto-generated documentation for standard library
+  * [ ] Enum to text for error messages
 
 REFACTORING
 ---
@@ -35,6 +36,8 @@ REFACTORING
   * [ ] Use [`libuv`](https://libuv.org) for non-blocking io
   * [ ] Std should be instantiated only once and pointed around instead of being cloned
   * [ ] Some structs are huge: mostly because we try to colocate most things. Do we need all of that?
+        - The only place where we need flexible lists is the tokenizer and parser.
+          From that point on all the lists have defined length and should be arrays.
 
 OPEN STUFF
 ---

--- a/.todo
+++ b/.todo
@@ -38,6 +38,8 @@ REFACTORING
   * [ ] Some structs are huge: mostly because we try to colocate most things. Do we need all of that?
         - The only place where we need flexible lists is the tokenizer and parser.
           From that point on all the lists have defined length and should be arrays.
+        - Having colocation though helps with copying, listAppend and mapSet, since we don't have
+          to follow pointers.
 
 OPEN STUFF
 ---

--- a/.todo
+++ b/.todo
@@ -25,6 +25,7 @@ FEATURES
   * [ ] Lexer should know about comments (and discard them)
   * [ ] Auto-generated documentation for standard library
   * [ ] Enum to text for error messages
+  * [ ] Currying: `(def! make-adder (fn (x) (fn (y) (+ x y))))\n(make-adder 5)` currently loses context on `x` because of immediate invocation
 
 REFACTORING
 ---

--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,5 +1,15 @@
 {
   "configurations": {
+    "run": {
+      "adapter": "CodeLLDB",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/bin/run",
+        "args": ["examples/fibonacci.lifp"],
+        "cwd": "${workspaceRoot}",
+        "stopAtEntry": true
+      }
+    },
     "repl": {
       "adapter": "CodeLLDB",
       "configuration": {

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ lifp/tokenize.o: lib/list.o lib/arena.o
 lifp/parse.o: lifp/tokenize.o lib/list.o lib/arena.o lifp/node.o
 lifp/node.o: lib/arena.o
 lifp/value.o: lib/arena.o lifp/node.o
-lifp/environment.o: lib/arena.o lib/map.o lifp/value.o
-lifp/evaluate.o: lib/arena.o lifp/environment.o lib/map.o lifp/value.o
+lifp/virtual_machine.o: lib/arena.o lib/map.o lifp/value.o
+lifp/evaluate.o: lib/arena.o lifp/virtual_machine.o lib/map.o lifp/value.o
 
 tests/tokenize.test: lifp/tokenize.o lib/list.o lib/arena.o
 tests/parser.test: \
@@ -27,27 +27,29 @@ tests/parser.test: \
 tests/list.test: lib/list.o lib/arena.o
 tests/arena.test: lib/arena.o
 tests/evaluate.test: \
-	lifp/evaluate.o lifp/node.o lib/list.o lib/arena.o lifp/environment.o \
+	lifp/evaluate.o lifp/node.o lib/list.o lib/arena.o lifp/virtual_machine.o \
 	lib/map.o lifp/value.o lifp/fmt.o
 tests/map.test: lib/arena.o lib/map.o
 tests/fmt.test: lifp/fmt.o lifp/node.o lib/arena.o lib/list.o lifp/value.o
 
 tests/integration.test: \
 	lifp/tokenize.o lifp/parse.o lib/arena.o lifp/evaluate.o lib/list.o \
-	lib/map.o lifp/node.o lifp/environment.o lifp/value.o lifp/fmt.o
+	lib/map.o lifp/node.o lifp/virtual_machine.o lifp/value.o lifp/fmt.o
 
 tests/memory.test: \
 	lifp/tokenize.o lifp/parse.o lib/arena.o lifp/evaluate.o lib/list.o \
-	lib/map.o lifp/node.o lifp/environment.o lifp/value.o lifp/fmt.o lib/profile.o
+	lib/map.o lifp/node.o lifp/virtual_machine.o lifp/value.o lifp/fmt.o \
+	lib/profile.o
 
 bin/repl: \
 	lifp/tokenize.o lifp/parse.o lib/list.o lifp/evaluate.o lifp/node.o \
-	lib/arena.o lifp/environment.o lib/map.o lib/profile.o lifp/fmt.o \
+	lib/arena.o lifp/virtual_machine.o lib/map.o lib/profile.o lifp/fmt.o \
 	lifp/value.o linenoise.o
 
 bin/run: \
 	lifp/tokenize.o lifp/parse.o lib/list.o lifp/evaluate.o lifp/node.o \
-	lib/arena.o lifp/environment.o lib/map.o lifp/fmt.o lifp/value.o lib/profile.o
+	lib/arena.o lifp/virtual_machine.o lib/map.o lifp/fmt.o lifp/value.o \
+	lib/profile.o
 
 
 .PHONY: clean

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -21,6 +21,8 @@ constexpr size_t AST_MEMORY = (size_t)(1024 * 64);
 // Memory allocated for storing transient values across environments
 constexpr size_t TEMP_MEMORY = (size_t)(1024 * 64);
 
+const char REPL_COMMAND_CLEAR[] = "clear";
+
 #define printError(Result, InputBuffer, Size, OutputBuffer)                    \
   int _concat(offset_, __LINE__) = 0;                                          \
   formatErrorMessage((Result)->message, (Result)->meta, "repl", InputBuffer,   \
@@ -71,6 +73,11 @@ int main(void) {
 
     if (strlen(input) == 0)
       continue;
+
+    if (strcmp(input, REPL_COMMAND_CLEAR) == 0) {
+      printf("\e[1;1H\e[2J");
+      continue;
+    }
 
     token_list_t *tokens = nullptr;
     tryREPL(tokenize(ast_arena, input), tokens);

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -87,14 +87,14 @@ int main(void) {
 
     size_t offset = 0;
     size_t depth = 0;
-    node_t *syntax_tree = nullptr;
-    tryREPL(parse(ast_arena, tokens, &offset, &depth), syntax_tree);
+    node_t *ast = nullptr;
+    tryREPL(parse(ast_arena, tokens, &offset, &depth), ast);
 
-    value_t reduced;
-    tryREPL(evaluate(&reduced, temp_arena, syntax_tree, global_environment));
+    value_t result;
+    tryREPL(evaluate(&result, temp_arena, ast, global_environment));
 
     int buffer_offset = 0;
-    formatValue(&reduced, BUFFER_SIZE, buffer, &buffer_offset);
+    formatValue(&result, BUFFER_SIZE, buffer, &buffer_offset);
     printf("~> %s\n", buffer);
 
     memset(buffer, 0, BUFFER_SIZE);

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -29,13 +29,13 @@ const char REPL_COMMAND_CLEAR[] = "clear";
                      Size, OutputBuffer, &_concat(offset_, __LINE__));         \
   fprintf(stdout, "%s\n", OutputBuffer);
 
-#define tryREPL(Action, Destination)                                           \
+#define tryREPL(Action, ...)                                                   \
   auto _concat(result, __LINE__) = Action;                                     \
   if (_concat(result, __LINE__).code != RESULT_OK) {                           \
     printError(&_concat(result, __LINE__), input, BUFFER_SIZE, buffer);        \
     continue;                                                                  \
   }                                                                            \
-  (Destination) = _concat(result, __LINE__).value;
+  __VA_OPT__(__VA_ARGS__ = _concat(result, __LINE__).value;)
 
 #define tryCLI(Action, Destination, ErrorMessage)                              \
   auto _concat(result, __LINE__) = Action;                                     \
@@ -90,11 +90,11 @@ int main(void) {
     node_t *syntax_tree = nullptr;
     tryREPL(parse(ast_arena, tokens, &offset, &depth), syntax_tree);
 
-    value_t *reduced = nullptr;
-    tryREPL(evaluate(temp_arena, syntax_tree, global_environment), reduced);
+    value_t reduced;
+    tryREPL(evaluate(&reduced, temp_arena, syntax_tree, global_environment));
 
     int buffer_offset = 0;
-    formatValue(reduced, BUFFER_SIZE, buffer, &buffer_offset);
+    formatValue(&reduced, BUFFER_SIZE, buffer, &buffer_offset);
     printf("~> %s\n", buffer);
 
     memset(buffer, 0, BUFFER_SIZE);

--- a/bin/repl.c
+++ b/bin/repl.c
@@ -1,11 +1,11 @@
 #include "../lib/arena.h"
 #include "../lib/profile.h"
-#include "../lifp/environment.h"
 #include "../lifp/evaluate.h"
 #include "../lifp/fmt.h"
 #include "../lifp/node.h"
 #include "../lifp/parse.h"
 #include "../lifp/tokenize.h"
+#include "../lifp/virtual_machine.h"
 #include "../vendor/linenoise/linenoise.h"
 #include <stdio.h>
 #include <string.h>
@@ -55,8 +55,7 @@ int main(void) {
          "unable to allocate transient memory");
 
   environment_t *global_environment = nullptr;
-  tryCLI(environmentCreate(nullptr), global_environment,
-         "unable to allocate virtual machine memory");
+  tryCLI(vmInit(), global_environment, "unable to initialize virtual machine");
 
   linenoiseSetMultiLine(1);
 

--- a/bin/run.c
+++ b/bin/run.c
@@ -28,14 +28,14 @@ constexpr size_t TEMP_MEMORY = (size_t)(1024 * 64);
     fprintf(stderr, "\n");                                                     \
   }
 
-#define tryRun(Action, Destination)                                            \
+#define tryRun(Action, ...)                                                    \
   auto _concat(result, __LINE__) = Action;                                     \
   if (_concat(result, __LINE__).code != RESULT_OK) {                           \
     error("%s", _concat(result, __LINE__).message);                            \
     profileReport();                                                           \
     return 1;                                                                  \
   }                                                                            \
-  (Destination) = _concat(result, __LINE__).value;
+  __VA_OPT__(__VA_ARGS__ = _concat(result, __LINE__).value;)
 
 #define tryCLI(Action, Destination, ErrorMessage)                              \
   auto _concat(result, __LINE__) = Action;                                     \
@@ -146,8 +146,8 @@ int main(int argc, char **argv) {
     node_t *syntax_tree = nullptr;
     tryRun(parse(ast_arena, tokens, &line_offset, &depth), syntax_tree);
 
-    value_t *reduced = nullptr;
-    tryRun(evaluate(temp_arena, syntax_tree, global_environment), reduced);
+    value_t reduced;
+    tryRun(evaluate(&reduced, temp_arena, syntax_tree, global_environment));
   } while (strlen(line_buffer) > 0);
 
   profileReport();

--- a/bin/run.c
+++ b/bin/run.c
@@ -1,7 +1,7 @@
-#include "../lifp/environment.h"
 #include "../lifp/evaluate.h"
 #include "../lifp/parse.h"
 #include "../lifp/tokenize.h"
+#include "../lifp/virtual_machine.h"
 
 #include "../lib/profile.h"
 
@@ -127,8 +127,7 @@ int main(int argc, char **argv) {
          "unable to allocate transient memory");
 
   environment_t *global_environment = nullptr;
-  tryCLI(environmentCreate(nullptr), global_environment,
-         "unable to allocate virtual machine memory");
+  tryCLI(vmInit(), global_environment, "unable to initialize virtual machine");
 
   do {
     memset(line_buffer, 0, (size_t)len);

--- a/bin/run.c
+++ b/bin/run.c
@@ -131,6 +131,8 @@ int main(int argc, char **argv) {
 
   do {
     memset(line_buffer, 0, (size_t)len);
+    arenaReset(ast_arena);
+    arenaReset(temp_arena);
     readLine(len, line_buffer, file_buffer, &file_offset);
 
     if (strlen(line_buffer) == 0)

--- a/examples/fact.lifp
+++ b/examples/fact.lifp
@@ -1,5 +1,5 @@
 (def! fact (fn (n) (cond ((< n 1) 1) (* n (fact (- n 1))))))
 
-(fact 10)
+(io.print! (fact 50))
 
 ; vim syntax=lisp

--- a/examples/fact.lifp
+++ b/examples/fact.lifp
@@ -1,0 +1,5 @@
+(def! fact (fn (n) (cond ((< n 1) 1) (* n (fact (- n 1))))))
+
+(fact 10)
+
+; vim syntax=lisp

--- a/examples/fibonacci.lifp
+++ b/examples/fibonacci.lifp
@@ -9,11 +9,8 @@
       ((< a 1) 0)
       ((= a 1) 1)
       ((= a 2) 2)
-      (let (
-        (last (fibonacci (- a 1)))
-        (current (fibonacci (- a 2))))
-        (+ last current)))))
+      (+ (fibonacci (- a 1)) (fibonacci (- a 2))))))
 
-(io.print! (fibonacci 18))
+(io.print! (fibonacci 30))
 
 ; vim syntax=lisp

--- a/examples/fibonacci.lifp
+++ b/examples/fibonacci.lifp
@@ -14,6 +14,6 @@
         (current (fibonacci (- a 2))))
         (+ last current)))))
 
-(io.print! (fibonacci 3))
+(io.print! (fibonacci 18))
 
 ; vim syntax=lisp

--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -58,25 +58,6 @@ typedef enum {
 typedef Result(void *) result_ref_t;
 
 /**
- * Copy bytes from source to destination memory locations.
- * @name bytewiseCopy
- * @param {void*} dest - Pointer to the destination memory location
- * @param {const void*} src - Pointer to the source memory location to copy from
- * @param {size_t} size - Number of bytes to copy
- * @example
- *   char source[] = "Hello";
- *   char dest[6];
- *   bytewiseCopy(dest, source, 6);  // dest now contains "Hello"
- */
-static inline void bytewiseCopy(void *dest, const void *src, size_t size) {
-  const auto dest_bytes = (unsigned char *)dest;
-  const auto src_bytes = (const unsigned char *)src;
-  for (size_t i = 0; i < size; i++) {
-    dest_bytes[i] = src_bytes[i];
-  }
-}
-
-/**
  * Safely allocate memory with error handling.
  * @name allocSafe
  * @param {size_t} size - Number of bytes to allocate

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -14,9 +14,9 @@ arena_metrics_t arena_metrics = {};
   arena_metrics.arenas_count++;
 
 #define arenaProfileEnd(Arena)                                                 \
-  for (size_t i = 0; i < arena_metrics.arenas_count; i++) {                    \
-    if (arena_metrics.arenas[i] == Arena) {                                    \
-      arena_metrics.freed[i] = true;                                           \
+  for (size_t i = arena_metrics.arenas_count; i > 0; i--) {                    \
+    if (arena_metrics.arenas[i - 1] == Arena && !arena_metrics.freed[i - 1]) { \
+      arena_metrics.freed[i - 1] = true;                                       \
       break;                                                                   \
     }                                                                          \
   }

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -71,3 +71,8 @@ void arenaDestroy(arena_t **self) {
 }
 
 void arenaReset(arena_t *self) { self->offset = 0; }
+
+frame_handle_t arenaAllocationFrameStart(arena_t *self) { return self->offset; }
+void arenaAllocationFrameEnd(arena_t *self, frame_handle_t frame_handle) {
+  self->offset = frame_handle;
+}

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -41,6 +41,7 @@
 
 typedef unsigned char byte_t;
 typedef char message_t[128];
+typedef size_t frame_handle_t;
 
 typedef enum {
   ARENA_ERROR_MALLOC_ERROR = 1,
@@ -103,6 +104,10 @@ result_ref_t arenaCreate(size_t size);
  *   }
  */
 result_ref_t arenaAllocate(arena_t *self, size_t size);
+
+frame_handle_t arenaAllocationFrameStart(arena_t *self);
+
+void arenaAllocationFrameEnd(arena_t *self, frame_handle_t frame_handle);
 
 /**
  * Destroy the arena and free all its memory.

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -105,8 +105,38 @@ result_ref_t arenaCreate(size_t size);
  */
 result_ref_t arenaAllocate(arena_t *self, size_t size);
 
+/**
+ * Marks the start of an allocation frame in the given arena.
+ * An allocation frame is a region in an arena which needs recycling before the
+ * arena's end of life.
+ *
+ * Frames can be nested, but ending a frame within another frame will leads to
+ * errors.
+ *
+ * @param {arena_t*} self - Pointer to the arena instance.
+ * @returns {frame_handle_t} A handle pointing to the frame, which can be used
+ * to restore the arena to this state later.
+ * @example
+ *    frame_handle_t frame = arenaAllocationFrameStart(arena);
+ *    // .. do the thing
+ *    arenaAllocationFrameEnd(frame);
+ */
 frame_handle_t arenaAllocationFrameStart(arena_t *self);
 
+/**
+ * Ends the allocation frame for the specified arena.
+ * All allocations made since the corresponding frame start may be released
+ * or invalidated. See `arenaAllocationFrameStart` for details.
+ *
+ * @param {arena_t*} self - Pointer to the arena instance.
+ * @param {frame_handle_t} frame_handle - A handle to the frame to end.
+ * @returns {frame_handle_t} A handle pointing to the frame, which can be used
+ * to restore the arena to this state later.
+ * @example
+ *    frame_handle_t frame = arenaAllocationFrameStart(arena);
+ *    // .. do the thing
+ *    arenaAllocationFrameEnd(frame);
+ */
 void arenaAllocationFrameEnd(arena_t *self, frame_handle_t frame_handle);
 
 /**

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -40,7 +40,7 @@
 #include "alloc.h"
 
 typedef unsigned char byte_t;
-typedef char message_t[64];
+typedef char message_t[128];
 
 typedef enum {
   ARENA_ERROR_MALLOC_ERROR = 1,

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -52,6 +52,9 @@ typedef enum {
  * @name arena_t
  */
 typedef struct {
+#ifdef DEBUG
+  int id;
+#endif
   size_t size;     // Total size of the arena memory buffer
   size_t offset;   // Current allocation offset within the buffer
   byte_t memory[]; // Flexible array member containing the actual memory buffer

--- a/lib/list.c
+++ b/lib/list.c
@@ -33,14 +33,14 @@ result_void_t genericListAppend(generic_list_t *self, const void *item) {
     try(result_void_t,
         arenaAllocate(self->arena, self->item_size * new_capacity), new_data);
 
-    memcpy(new_data, self->data, self->item_size * self->count);
+    memmove(new_data, self->data, self->item_size * self->count);
 
     self->data = new_data;
     self->capacity = new_capacity;
   }
 
   void *destination = (byte_t *)self->data + (self->item_size * self->count);
-  memcpy(destination, item, self->item_size);
+  memmove(destination, item, self->item_size);
   self->count++;
 
   return ok(result_void_t);

--- a/lib/list.c
+++ b/lib/list.c
@@ -2,6 +2,7 @@
 #include "arena.h"
 #include "result.h"
 #include <assert.h>
+#include <string.h>
 
 result_ref_t genericListCreate(arena_t *arena, size_t capacity,
                                size_t list_size, size_t item_size) {
@@ -32,14 +33,14 @@ result_void_t genericListAppend(generic_list_t *self, const void *item) {
     try(result_void_t,
         arenaAllocate(self->arena, self->item_size * new_capacity), new_data);
 
-    bytewiseCopy(new_data, self->data, self->item_size * self->count);
+    memcpy(new_data, self->data, self->item_size * self->count);
 
     self->data = new_data;
     self->capacity = new_capacity;
   }
 
   void *destination = (byte_t *)self->data + (self->item_size * self->count);
-  bytewiseCopy(destination, item, self->item_size);
+  memcpy(destination, item, self->item_size);
   self->count++;
 
   return ok(result_void_t);
@@ -71,5 +72,20 @@ result_void_t genericListCopy(const generic_list_t *source,
   }
 
   destination->count = source->count;
+  return ok(result_void_t);
+}
+
+result_void_t genericListUnshift(generic_list_t *self) {
+  assert(self);
+
+  if (self->count <= 0) {
+    throw(result_void_t, LIST_ERROR_EMPTY_LIST, nullptr,
+          "Cannot unshift empty list");
+  }
+
+  memmove(self->data, (char *)self->data + self->item_size,
+          self->item_size * (self->count - 1));
+  self->count--;
+
   return ok(result_void_t);
 }

--- a/lib/list.h
+++ b/lib/list.h
@@ -40,6 +40,7 @@
 typedef enum {
   LIST_ERROR_ALLOCATION = ARENA_ERROR_OUT_OF_SPACE,
   LIST_ERROR_INCOMPATIBLE_LISTS,
+  LIST_ERROR_EMPTY_LIST,
 } list_error_t;
 
 /**
@@ -133,6 +134,8 @@ typedef List(void) generic_list_t;
   genericListCopy((const generic_list_t *)(Source),                            \
                   (generic_list_t *)(Destination))
 
+#define listUnshift(ItemType, List) genericListUnshift((generic_list_t *)(List))
+
 result_ref_t genericListCreate(arena_t *arena, size_t capacity,
                                size_t list_size, size_t item_size);
 result_void_t genericListAppend(generic_list_t *self, const void *item);
@@ -141,3 +144,4 @@ void *genericListGet(const generic_list_t *self, size_t index);
 
 result_void_t genericListCopy(const generic_list_t *source,
                               generic_list_t *destination);
+result_void_t genericListUnshift(generic_list_t *self);

--- a/lib/list.h
+++ b/lib/list.h
@@ -134,6 +134,18 @@ typedef List(void) generic_list_t;
   genericListCopy((const generic_list_t *)(Source),                            \
                   (generic_list_t *)(Destination))
 
+/**
+ * Remove the first element from the list (unshift operation).
+ * @name listUnshift
+ * @param {Type} ItemType - The type of values stored in the list
+ * @param {List(Type)*} List - Pointer to the list
+ * @returns {result_void_t} Success or error if the list is empty
+ * @example
+ *   result_void_t result = listUnshift(int, list);
+ *   if (!result.ok) {
+ *       // Handle error (e.g., empty list)
+ *   }
+ */
 #define listUnshift(ItemType, List) genericListUnshift((generic_list_t *)(List))
 
 result_ref_t genericListCreate(arena_t *arena, size_t capacity,

--- a/lib/profile.c
+++ b/lib/profile.c
@@ -176,16 +176,16 @@ void printArenas(void) {
     if (arena_metrics.freed[i]) {
       freed++;
     } else {
-      printf("    arena[%lu]: %lu/%lu bytes (%0.2f%%)\n", i, arena->offset,
+      printf("  arena[%lu]: %lu/%lu bytes (%0.2f%%)\n", i, arena->offset,
              arena->size,
              (double)(arena->offset * 100) / (double)(arena->size));
     }
   }
 
   printf("\n"
-         "    Stats:\n"
-         "      tracked:   %lu arenas\n"
-         "      destroyed: %lu arenas\n",
+         "  Stats:\n"
+         "    tracked:   %lu arenas\n"
+         "    destroyed: %lu arenas\n",
          arena_metrics.arenas_count, freed);
 }
 

--- a/lib/result.h
+++ b/lib/result.h
@@ -51,19 +51,37 @@ typedef Result(int) test_t;
   }                                                                            \
   __VA_OPT__(__VA_ARGS__ = (_result(ResultType).value));
 
-#define tryWithCleanup(ResultType, Action, Cleanup, ...)                       \
+#define tryCatch(ResultType, Action, Catch, ...)                               \
   auto _result(ResultType) = Action;                                           \
   if (_result(ResultType).code != RESULT_OK) {                                 \
-    Cleanup;                                                                   \
+    Catch;                                                                     \
     throw(ResultType, _result(ResultType).code, _result(ResultType).meta,      \
           "%s", _result(ResultType).message);                                  \
   }                                                                            \
   __VA_OPT__(__VA_ARGS__ = (_result(ResultType).value));
 
-#define tryWithCleanupMeta(ResultType, Action, Cleanup, Meta, ...)             \
+#define tryCatchWithMeta(ResultType, Action, Catch, Meta, ...)                 \
   auto _result(ResultType) = Action;                                           \
   if (_result(ResultType).code != RESULT_OK) {                                 \
-    Cleanup;                                                                   \
+    Catch;                                                                     \
+    throw(ResultType, _result(ResultType).code, Meta, "%s",                    \
+          _result(ResultType).message);                                        \
+  }                                                                            \
+  __VA_OPT__(__VA_ARGS__ = (_result(ResultType).value));
+
+#define tryFinally(ResultType, Action, Finally, ...)                           \
+  auto _result(ResultType) = Action;                                           \
+  Finally;                                                                     \
+  if (_result(ResultType).code != RESULT_OK) {                                 \
+    throw(ResultType, _result(ResultType).code, _result(ResultType).meta,      \
+          "%s", _result(ResultType).message);                                  \
+  }                                                                            \
+  __VA_OPT__(__VA_ARGS__ = (_result(ResultType).value));
+
+#define tryFinallyWithMeta(ResultType, Action, Finally, Meta, ...)             \
+  auto _result(ResultType) = Action;                                           \
+  Finally;                                                                     \
+  if (_result(ResultType).code != RESULT_OK) {                                 \
     throw(ResultType, _result(ResultType).code, Meta, "%s",                    \
           _result(ResultType).message);                                        \
   }                                                                            \

--- a/lib/result.h
+++ b/lib/result.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <stdio.h>
-typedef char message_t[64];
+typedef char message_t[128];
 
 constexpr int RESULT_OK = 0;
 

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -24,168 +24,163 @@ static bool isSpecialFormNode(const node_t FIRST_NODE) {
           (strncmp(FIRST_NODE.value.symbol, COND, 4) == 0 && len == 4)) != 0;
 }
 
-static result_value_ref_t invokeBuiltin(value_t *result, value_t builtin_value,
-                                        arena_t *arena) {
+static result_void_position_t
+invokeBuiltin(value_t *result, value_list_t *evaluated, value_t builtin_value) {
   assert(builtin_value.type == VALUE_TYPE_BUILTIN);
   builtin_t builtin = builtin_value.value.builtin;
-
-  // Prepare argument list with all values except for the symbol
-  value_list_t *arguments = nullptr;
-  tryWithMeta(result_value_ref_t,
-              listCreate(value_t, arena, result->value.list.count - 1),
-              builtin_value.position, arguments);
-
-  for (size_t i = 1; i < result->value.list.count; i++) {
-    value_t argument = listGet(value_t, &result->value.list, i);
-    tryWithMeta(result_value_ref_t, listAppend(value_t, arguments, &argument),
-                argument.position);
-  }
-
-  try(result_value_ref_t, builtin(result, arguments));
-  return ok(result_value_ref_t, result);
+  listUnshift(value_t, evaluated);
+  try(result_void_position_t, builtin(result, evaluated));
+  return ok(result_void_position_t);
 }
 
-static result_value_ref_t invokeClosure(value_t *result, value_t closure_value,
-                                        arena_t *arena,
-                                        environment_t *parent_environment) {
+static result_void_position_t
+invokeClosure(value_t *result, value_list_t *evaluated, value_t closure_value,
+              arena_t *arena, environment_t *parent_environment) {
   assert(closure_value.type == VALUE_TYPE_CLOSURE);
   closure_t closure = closure_value.value.closure;
 
-  if (result->value.list.count - 1 != closure.arguments.count) {
-    throw(result_value_ref_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
+  if (evaluated->count - 1 != closure.arguments.count) {
+    throw(result_void_position_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
           closure_value.position,
           "Unexpected arity. Expected %lu arguments, got %lu.",
-          result->value.list.count - 1, closure.arguments.count);
+          closure.arguments.count, evaluated->count - 1);
   }
 
   environment_t *local_environment = nullptr;
-  tryWithMeta(result_value_ref_t, environmentCreate(parent_environment),
+  tryWithMeta(result_void_position_t, environmentCreate(parent_environment),
               closure_value.position, local_environment);
 
   // Populate the closure with the values, skipping the closure symbol
-  for (size_t i = 1; i < result->value.list.count; i++) {
+  for (size_t i = 1; i < evaluated->count; i++) {
     auto argument = listGet(node_t, &closure.arguments, i - 1);
-    auto value = listGet(value_t, &result->value.list, i);
+    auto value = listGet(value_t, evaluated, i);
     tryCatchWithMeta(
-        result_value_ref_t,
+        result_void_position_t,
         mapSet(local_environment->values, argument.value.symbol, &value),
         environmentDestroy(&local_environment), value.position);
   }
 
-  value_t *reduced = nullptr;
-  tryFinally(result_value_ref_t,
-             evaluate(arena, &closure.form, local_environment),
-             environmentDestroy(&local_environment), reduced);
+  // TODO: even better here would be to bubble up where in the form the error
+  // occurs as opposed to point to the call site
+  tryFinallyWithMeta(result_void_position_t,
+                     evaluate(result, arena, &closure.form, local_environment),
+                     environmentDestroy(&local_environment),
+                     closure_value.position);
 
-  return ok(result_value_ref_t, reduced);
+  return ok(result_void_position_t);
 }
 
-static result_value_ref_t invokeSpecialForm(arena_t *arena, value_t *result,
-                                            node_t form_node,
-                                            const node_list_t *nodes,
-                                            environment_t *environment) {
+static result_void_position_t invokeSpecialForm(arena_t *arena, value_t *result,
+                                                node_t form_node,
+                                                const node_list_t *nodes,
+                                                environment_t *environment) {
   if (form_node.value.symbol[0] == 'd') {
-    try(result_value_ref_t, define(arena, environment, nodes), result);
+    try(result_void_position_t, define(result, arena, environment, nodes));
   } else if (form_node.value.symbol[0] == 'f') {
-    try(result_value_ref_t, function(arena, environment, nodes), result);
+    try(result_void_position_t, function(result, arena, environment, nodes));
   } else if (form_node.value.symbol[0] == 'l') {
-    try(result_value_ref_t, let(arena, environment, nodes), result);
+    try(result_void_position_t, let(result, arena, environment, nodes));
   } else {
-    try(result_value_ref_t, cond(arena, environment, nodes), result);
+    try(result_void_position_t, cond(result, arena, environment, nodes));
   }
 
-  return ok(result_value_ref_t, result);
+  return ok(result_void_position_t);
 }
 
-result_value_ref_t evaluateList(arena_t *arena, node_t *syntax_tree,
-                                environment_t *environment) {
-  const auto list = syntax_tree->value.list;
-
-  value_t *result = nullptr;
-  tryWithMeta(result_value_ref_t, valueCreate(arena, VALUE_TYPE_LIST),
-              syntax_tree->position, result);
-  result->position.column = syntax_tree->position.column;
-  result->position.line = syntax_tree->position.line;
-
-  if (list.count == 0) {
-    return ok(result_value_ref_t, result);
-  }
-
-  auto first_node = listGet(node_t, &list, 0);
-  if (isSpecialFormNode(first_node)) {
-    return invokeSpecialForm(arena, result, first_node, &list, environment);
-  }
-
-  for (size_t i = 0; i < list.count; i++) {
-    frame_handle_t frame = arenaAllocationFrameStart(arena);
-    auto node = listGet(node_t, &list, i);
-    value_t *reduced = nullptr;
-    try(result_value_ref_t, evaluate(arena, &node, environment), reduced);
-    tryWithMeta(result_value_ref_t,
-                listAppend(value_t, &result->value.list, reduced),
-                syntax_tree->position);
-    arenaAllocationFrameEnd(arena, frame);
-  }
-
-  value_t first_value = listGet(value_t, &result->value.list, 0);
-
-  if (first_value.type == VALUE_TYPE_BUILTIN) {
-    return invokeBuiltin(result, first_value, arena);
-  }
-
-  if (first_value.type == VALUE_TYPE_CLOSURE) {
-    return invokeClosure(result, first_value, arena, environment);
-  }
-
-  return ok(result_value_ref_t, result);
-}
-
-result_value_ref_t evaluate(arena_t *arena, node_t *syntax_tree,
-                            environment_t *environment) {
+result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
+                                node_t *ast, environment_t *env) {
   profileSafeAlloc();
   profileArena(arena);
 
-  value_t *value = nullptr;
-  tryWithMeta(result_value_ref_t, valueCreate(arena, VALUE_TYPE_INTEGER),
-              syntax_tree->position, value);
-  value->position.column = syntax_tree->position.column;
-  value->position.line = syntax_tree->position.line;
+  result->position.column = ast->position.column;
+  result->position.line = ast->position.line;
 
-  switch (syntax_tree->type) {
+  switch (ast->type) {
   case NODE_TYPE_BOOLEAN: {
-    value->type = VALUE_TYPE_BOOLEAN;
-    value->value.boolean = syntax_tree->value.boolean;
-    break;
+    result->type = VALUE_TYPE_BOOLEAN;
+    result->value.boolean = ast->value.boolean;
+    return ok(result_void_position_t);
   }
   case NODE_TYPE_NIL: {
-    value->type = VALUE_TYPE_NIL;
-    value->value.nil = nullptr;
-    break;
+    result->type = VALUE_TYPE_NIL;
+    result->value.nil = ast->value.nil;
+    return ok(result_void_position_t);
   }
   case NODE_TYPE_INTEGER: {
-    value->type = VALUE_TYPE_INTEGER;
-    value->value.integer = syntax_tree->value.integer;
-    break;
+    result->type = VALUE_TYPE_INTEGER;
+    result->value.integer = ast->value.integer;
+    return ok(result_void_position_t);
   }
   case NODE_TYPE_SYMBOL: {
     const value_t *resolved_value =
-        environmentResolveSymbol(environment, syntax_tree->value.symbol);
+        environmentResolveSymbol(env, ast->value.symbol);
 
     if (!resolved_value) {
-      throw(result_value_ref_t, ERROR_CODE_REFERENCE_SYMBOL_NOT_FOUND,
-            syntax_tree->position,
+      throw(result_void_position_t, ERROR_CODE_REFERENCE_SYMBOL_NOT_FOUND,
+            result->position,
             "Symbol '%s' cannot be found in the current environment",
-            syntax_tree->value.symbol);
+            ast->value.symbol);
     }
 
-    value->type = resolved_value->type;
-    value->value = resolved_value->value;
-    break;
+    result->type = resolved_value->type;
+    result->value = resolved_value->value;
+    return ok(result_void_position_t);
   }
-  case NODE_TYPE_LIST:
-    return evaluateList(arena, syntax_tree, environment);
+  case NODE_TYPE_LIST: {
+    const auto list = ast->value.list;
+
+    if (list.count == 0) {
+      result->type = VALUE_TYPE_LIST;
+      result->value.list.count = 0;
+      result->value.list.capacity = 0;
+      result->value.list.data = nullptr;
+      result->value.list.arena = temp_arena;
+      return ok(result_void_position_t);
+    }
+
+    auto first_node = listGet(node_t, &list, 0);
+    if (isSpecialFormNode(first_node)) {
+      return invokeSpecialForm(temp_arena, result, first_node, &list, env);
+    }
+
+    value_list_t *evaluated;
+    frame_handle_t frame = arenaAllocationFrameStart(temp_arena);
+    tryWithMeta(result_void_position_t,
+                listCreate(value_t, temp_arena, list.count),
+                first_node.position, evaluated);
+
+    for (size_t i = 0; i < list.count; i++) {
+      auto node = listGet(node_t, &list, i);
+      value_t reduced;
+      try(result_void_position_t, evaluate(&reduced, temp_arena, &node, env));
+      listAppend(value_t, evaluated, &reduced);
+    }
+
+    value_t first_value = listGet(value_t, evaluated, 0);
+
+    switch (first_value.type) {
+    case VALUE_TYPE_BUILTIN:
+      tryFinally(result_void_position_t,
+                 invokeBuiltin(result, evaluated, first_value),
+                 arenaAllocationFrameEnd(temp_arena, frame));
+      return ok(result_void_position_t);
+    case VALUE_TYPE_CLOSURE:
+      // this this needs the evaluated list
+      tryFinally(result_void_position_t,
+                 invokeClosure(result, evaluated, first_value, temp_arena, env),
+                 arenaAllocationFrameEnd(temp_arena, frame));
+      return ok(result_void_position_t);
+    case VALUE_TYPE_INTEGER:
+    case VALUE_TYPE_LIST:
+    case VALUE_TYPE_NIL:
+    case VALUE_TYPE_BOOLEAN:
+    default:
+      result->type = VALUE_TYPE_LIST;
+      result->value.list = *evaluated;
+      return ok(result_void_position_t);
+    }
+  }
   default:
     unreachable();
   }
-  return ok(result_value_ref_t, value);
 }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -90,7 +90,7 @@ static result_void_position_t invokeSpecialForm(arena_t *arena, value_t *result,
 result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
                                 node_t *ast, environment_t *env) {
   profileSafeAlloc();
-  profileArena(arena);
+  profileArena(temp_arena);
 
   result->position.column = ast->position.column;
   result->position.line = ast->position.line;
@@ -165,7 +165,6 @@ result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
                  arenaAllocationFrameEnd(temp_arena, frame));
       return ok(result_void_position_t);
     case VALUE_TYPE_CLOSURE:
-      // this this needs the evaluated list
       tryFinally(result_void_position_t,
                  invokeClosure(result, evaluated, first_value, temp_arena, env),
                  arenaAllocationFrameEnd(temp_arena, frame));

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -152,7 +152,9 @@ result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
     for (size_t i = 0; i < list.count; i++) {
       auto node = listGet(node_t, &list, i);
       value_t reduced;
-      try(result_void_position_t, evaluate(&reduced, temp_arena, &node, env));
+      tryCatch(result_void_position_t,
+               evaluate(&reduced, temp_arena, &node, env),
+               arenaAllocationFrameEnd(temp_arena, frame));
       tryWithMeta(result_void_position_t,
                   listAppend(value_t, evaluated, &reduced), node.position);
     }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -153,7 +153,8 @@ result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
       auto node = listGet(node_t, &list, i);
       value_t reduced;
       try(result_void_position_t, evaluate(&reduced, temp_arena, &node, env));
-      listAppend(value_t, evaluated, &reduced);
+      tryWithMeta(result_void_position_t,
+                  listAppend(value_t, evaluated, &reduced), node.position);
     }
 
     value_t first_value = listGet(value_t, evaluated, 0);
@@ -175,7 +176,8 @@ result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
     case VALUE_TYPE_BOOLEAN:
     default:
       result->type = VALUE_TYPE_LIST;
-      result->value.list = *evaluated;
+      memcpy(&result->value.list, evaluated, sizeof(result->value.list));
+      arenaAllocationFrameEnd(temp_arena, frame);
       return ok(result_void_position_t);
     }
   }

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -1,9 +1,9 @@
 #include "evaluate.h"
 #include "../lib/profile.h"
-#include "environment.h"
 #include "error.h"
 #include "node.h"
 #include "value.h"
+#include "virtual_machine.h"
 
 // NOLINTNEXTLINE
 #include "specials.c"

--- a/lifp/evaluate.h
+++ b/lifp/evaluate.h
@@ -5,5 +5,5 @@
 #include "value.h"
 #include "virtual_machine.h"
 
-result_value_ref_t evaluate(arena_t *arena, node_t *syntax_tree,
-                            environment_t *environment);
+result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
+                                node_t *ast, environment_t *env);

--- a/lifp/evaluate.h
+++ b/lifp/evaluate.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "../lib/arena.h"
-#include "environment.h"
 #include "node.h"
 #include "value.h"
+#include "virtual_machine.h"
 
 result_value_ref_t evaluate(arena_t *arena, node_t *syntax_tree,
                             environment_t *environment);

--- a/lifp/node.c
+++ b/lifp/node.c
@@ -1,4 +1,5 @@
 #include "node.h"
+#include <string.h>
 
 static constexpr size_t INITIAL_SIZE = 8;
 
@@ -9,7 +10,7 @@ result_ref_t nodeCreate(arena_t *arena, node_type_t type) {
   if (type == NODE_TYPE_LIST) {
     node_list_t *list = nullptr;
     try(result_ref_t, listCreate(node_t, arena, INITIAL_SIZE), list);
-    bytewiseCopy(&node->value.list, list, sizeof(node_list_t));
+    memcpy(&node->value.list, list, sizeof(node_list_t));
   }
 
   node->type = type;

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -10,117 +10,114 @@
 #include <stddef.h>
 #include <string.h>
 
-typedef result_value_ref_t (*special_form_t)(arena_t *, environment_t *,
-                                             const node_list_t *);
+typedef result_void_position_t (*special_form_t)(value_t *, arena_t *,
+                                                 environment_t *,
+                                                 const node_list_t *);
 
 const char *DEFINE_EXAMPLE = "(def! x (+ 1 2))";
 const char *DEFINE = "def!";
-result_value_ref_t define(arena_t *arena, environment_t *env,
-                          const node_list_t *nodes) {
+result_void_position_t define(value_t *result, arena_t *temp_arena,
+                              environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0); // def! is always there
   node_t first = listGet(node_t, nodes, 0);
   if (nodes->count != 3) {
-    throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, first.position,
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, first.position,
           "%s requires a symbol and a form. %s", DEFINE, DEFINE_EXAMPLE);
   }
 
   node_t key = listGet(node_t, nodes, 1);
   if (key.type != NODE_TYPE_SYMBOL) {
-    throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, first.position,
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, first.position,
           "%s requires a symbol and a form. %s", DEFINE, DEFINE_EXAMPLE);
   }
 
   // Perform reduction in the temporary memory
-  frame_handle_t frame = arenaAllocationFrameStart(arena);
-  value_t *result = nullptr;
+  frame_handle_t frame = arenaAllocationFrameStart(temp_arena);
+  value_t *reduced;
+  tryWithMeta(result_void_position_t, valueCreate(temp_arena), result->position,
+              reduced);
   node_t value = listGet(node_t, nodes, 2);
-  tryFinally(result_value_ref_t, evaluate(arena, &value, env),
-             arenaAllocationFrameEnd(arena, frame), result);
+  try(result_void_position_t, evaluate(reduced, temp_arena, &value, env));
 
   // If reduction is successful, we can move the closure to VM memory
-  value_t *copy = nullptr;
-  tryWithMeta(result_value_ref_t, valueClone(env->arena, result),
-              value.position, copy);
-  tryWithMeta(result_value_ref_t, mapSet(env->values, key.value.symbol, copy),
-              value.position);
+  value_t *copied = nullptr;
+  tryWithMeta(result_void_position_t, valueCreate(env->arena), result->position,
+              copied);
+  tryWithMeta(result_void_position_t, valueCopy(reduced, copied, env->arena),
+              result->position);
+  tryWithMeta(result_void_position_t,
+              mapSet(env->values, key.value.symbol, copied), value.position);
+  arenaAllocationFrameEnd(temp_arena, frame);
 
-  value_t nil = {
-      .type = VALUE_TYPE_NIL,
-      .value.nil = nullptr,
-      .position = first.position,
-  };
-  return ok(result_value_ref_t, &nil);
+  result->type = VALUE_TYPE_NIL;
+  result->value.nil = nullptr;
+  result->position = first.position;
+  return ok(result_void_position_t);
 }
 
 const char *FUNCTION_EXAMPLE = "(fn (a b) (+ a b))";
 const char *FUNCTION = "fn";
-result_value_ref_t function(arena_t *arena, environment_t *env,
-                            const node_list_t *nodes) {
+result_void_position_t function(value_t *result, arena_t *temp_arena,
+                                environment_t *env, const node_list_t *nodes) {
   (void)env;
   assert(nodes->count > 0); // fn is always there
   node_t first = listGet(node_t, nodes, 0);
   if (nodes->count != 3) {
-    throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, first.position,
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, first.position,
           "%s requires a binding list and a form. %s", FUNCTION,
           FUNCTION_EXAMPLE);
   }
 
   node_t arguments = listGet(node_t, nodes, 1);
   if (arguments.type != NODE_TYPE_LIST) {
-    throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, arguments.position,
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, arguments.position,
           "%s requires a binding list and a form. %s", FUNCTION,
           FUNCTION_EXAMPLE);
   }
 
+  node_t form = listGet(node_t, nodes, 2);
+
+  tryWithMeta(result_void_position_t,
+              valueInit(result, temp_arena, VALUE_TYPE_CLOSURE, form.type),
+              result->position);
+
   for (size_t i = 0; i < arguments.value.list.count; i++) {
     node_t argument = listGet(node_t, &arguments.value.list, i);
     if (argument.type != NODE_TYPE_SYMBOL) {
-      throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, argument.position,
+      throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, argument.position,
             "%s requires a binding list of symbols. %s", FUNCTION,
             FUNCTION_EXAMPLE);
     }
+    listAppend(node_t, &result->value.closure.arguments, &argument);
   }
 
-  node_t form = listGet(node_t, nodes, 2);
+  tryWithMeta(result_void_position_t,
+              nodeCopy(&form, &result->value.closure.form), form.position);
 
-  value_t *closure = nullptr;
-  tryWithMeta(result_value_ref_t, valueCreate(arena, VALUE_TYPE_CLOSURE),
-              form.position, closure);
-
-  closure->position.column = first.position.column;
-  closure->position.line = first.position.line;
-
-  tryWithMeta(result_value_ref_t,
-              listCopy(node_t, &arguments.value.list,
-                       &closure->value.closure.arguments),
-              form.position);
-  tryWithMeta(result_value_ref_t, nodeCopy(&form, &closure->value.closure.form),
-              form.position);
-
-  return ok(result_value_ref_t, closure);
+  return ok(result_void_position_t);
 }
 
 const char *LET_EXAMPLE = "(let ((a 1) (b 2)) (+ a b))";
 const char *LET = "let";
-result_value_ref_t let(arena_t *arena, environment_t *env,
-                       const node_list_t *nodes) {
+result_void_position_t let(value_t *result, arena_t *temp_arena,
+                           environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0); // let is always there
   node_t first = listGet(node_t, nodes, 0);
   if (nodes->count != 3) {
-    throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, first.position,
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, first.position,
           "%s requires a list of symbol-form assignments. %s", LET,
           LET_EXAMPLE);
   }
 
   node_t couples = listGet(node_t, nodes, 1);
   if (couples.type != NODE_TYPE_LIST) {
-    throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, couples.position,
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, couples.position,
           "%s requires a list of symbol-form assignments. %s", LET,
           LET_EXAMPLE);
   }
 
   environment_t *local_env = nullptr;
-  tryWithMeta(result_value_ref_t, environmentCreate(env), couples.position,
+  tryWithMeta(result_void_position_t, environmentCreate(env), couples.position,
               local_env);
 
   for (size_t i = 0; i < couples.value.list.count; i++) {
@@ -128,7 +125,7 @@ result_value_ref_t let(arena_t *arena, environment_t *env,
 
     if (couple.type != NODE_TYPE_LIST || couple.value.list.count != 2) {
       environmentDestroy(&local_env);
-      throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, couple.position,
+      throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, couple.position,
             "%s requires a list of symbol-form assignments. %s", LET,
             LET_EXAMPLE);
     }
@@ -136,64 +133,67 @@ result_value_ref_t let(arena_t *arena, environment_t *env,
     node_t symbol = listGet(node_t, &couple.value.list, 0);
     if (symbol.type != NODE_TYPE_SYMBOL) {
       environmentDestroy(&local_env);
-      throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, symbol.position,
+      throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, symbol.position,
             "%s requires a list of symbol-form assignments. %s", LET,
             LET_EXAMPLE);
     }
 
     node_t body = listGet(node_t, &couple.value.list, 1);
-    frame_handle_t bindings_frame = arenaAllocationFrameStart(arena);
+    frame_handle_t bindings_frame = arenaAllocationFrameStart(temp_arena);
     value_t *evaluated = nullptr;
-    tryCatch(result_value_ref_t, evaluate(arena, &body, local_env),
-             environmentDestroy(&local_env), evaluated);
-    tryCatchWithMeta(result_value_ref_t,
+    tryWithMeta(result_void_position_t, valueCreate(temp_arena), body.position,
+                evaluated);
+    tryCatch(result_void_position_t,
+             evaluate(evaluated, temp_arena, &body, local_env),
+             environmentDestroy(&local_env));
+    tryCatchWithMeta(result_void_position_t,
                      mapSet(local_env->values, symbol.value.symbol, evaluated),
                      environmentDestroy(&local_env), evaluated->position);
-    arenaAllocationFrameEnd(arena, bindings_frame);
+    arenaAllocationFrameEnd(temp_arena, bindings_frame);
   }
 
   node_t form = listGet(node_t, nodes, 2);
+  tryFinally(result_void_position_t,
+             evaluate(result, temp_arena, &form, local_env),
+             environmentDestroy(&local_env));
 
-  value_t *result = nullptr;
-  tryFinally(result_value_ref_t, evaluate(arena, &form, local_env),
-             environmentDestroy(&local_env), result);
-
-  return ok(result_value_ref_t, result);
+  return ok(result_void_position_t);
 }
 
 const char *COND_EXAMPLE = "\n  (cond\n    ((!= x 0) (/ 10 x))\n    (+ x 10))";
 const char *COND = "cond";
-result_value_ref_t cond(arena_t *arena, environment_t *env,
-                        const node_list_t *nodes) {
+result_void_position_t cond(value_t *result, arena_t *temp_arena,
+                            environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0);
-  value_t *result = nullptr;
 
   for (size_t i = 1; i < nodes->count - 1; i++) {
-    frame_handle_t frame = arenaAllocationFrameStart(arena);
+    frame_handle_t frame = arenaAllocationFrameStart(temp_arena);
     node_t node = listGet(node_t, nodes, i);
     if (node.type != NODE_TYPE_LIST || node.value.list.count != 2) {
-      throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, node.position,
+      arenaAllocationFrameEnd(temp_arena, frame);
+      throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, node.position,
             "%s requires a list of condition-form assignments. %s", COND,
             COND_EXAMPLE);
     }
 
     node_t condition = listGet(node_t, &node.value.list, 0);
-    try(result_value_ref_t, evaluate(arena, &condition, env), result);
+    try(result_void_position_t, evaluate(result, temp_arena, &condition, env));
 
     if (result->type != VALUE_TYPE_BOOLEAN) {
-      throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, node.position,
+      arenaAllocationFrameEnd(temp_arena, frame);
+      throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, node.position,
             "Conditions should resolve to a boolean. %s", COND_EXAMPLE);
     }
 
     if (result->value.boolean) {
       node_t form = listGet(node_t, &node.value.list, 1);
-      try(result_value_ref_t, evaluate(arena, &form, env), result);
-      return ok(result_value_ref_t, result);
+      try(result_void_position_t, evaluate(result, temp_arena, &form, env));
+      return ok(result_void_position_t);
     }
-    arenaAllocationFrameEnd(arena, frame);
+    arenaAllocationFrameEnd(temp_arena, frame);
   }
 
   node_t fallback = listGet(node_t, nodes, nodes->count - 1);
-  try(result_value_ref_t, evaluate(arena, &fallback, env), result);
-  return ok(result_value_ref_t, result);
+  try(result_void_position_t, evaluate(result, temp_arena, &fallback, env));
+  return ok(result_void_position_t);
 }

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -10,12 +10,13 @@
 #include <stddef.h>
 #include <string.h>
 
-typedef result_value_ref_t (*special_form_t)(environment_t *,
+typedef result_value_ref_t (*special_form_t)(arena_t *, environment_t *,
                                              const node_list_t *);
 
 const char *DEFINE_EXAMPLE = "(def! x (+ 1 2))";
 const char *DEFINE = "def!";
-result_value_ref_t define(environment_t *env, const node_list_t *nodes) {
+result_value_ref_t define(arena_t *arena, environment_t *env,
+                          const node_list_t *nodes) {
   assert(nodes->count > 0); // def! is always there
   node_t first = listGet(node_t, nodes, 0);
   if (nodes->count != 3) {
@@ -32,7 +33,7 @@ result_value_ref_t define(environment_t *env, const node_list_t *nodes) {
   // Perform reduction in the AST memory
   value_t *result = nullptr;
   node_t value = listGet(node_t, nodes, 2);
-  try(result_value_ref_t, evaluate(nodes->arena, &value, env), result);
+  try(result_value_ref_t, evaluate(arena, &value, env), result);
 
   // If reduction is successful, we can move the closure to VM memory
   value_t *copy = nullptr;
@@ -51,7 +52,8 @@ result_value_ref_t define(environment_t *env, const node_list_t *nodes) {
 
 const char *FUNCTION_EXAMPLE = "(fn (a b) (+ a b))";
 const char *FUNCTION = "fn";
-result_value_ref_t function(environment_t *env, const node_list_t *nodes) {
+result_value_ref_t function(arena_t *arena, environment_t *env,
+                            const node_list_t *nodes) {
   (void)env;
   assert(nodes->count > 0); // fn is always there
   node_t first = listGet(node_t, nodes, 0);
@@ -80,7 +82,7 @@ result_value_ref_t function(environment_t *env, const node_list_t *nodes) {
   node_t form = listGet(node_t, nodes, 2);
 
   value_t *closure = nullptr;
-  tryWithMeta(result_value_ref_t, valueCreate(nodes->arena, VALUE_TYPE_CLOSURE),
+  tryWithMeta(result_value_ref_t, valueCreate(arena, VALUE_TYPE_CLOSURE),
               form.position, closure);
 
   closure->position.column = first.position.column;
@@ -98,7 +100,8 @@ result_value_ref_t function(environment_t *env, const node_list_t *nodes) {
 
 const char *LET_EXAMPLE = "(let ((a 1) (b 2)) (+ a b))";
 const char *LET = "let";
-result_value_ref_t let(environment_t *env, const node_list_t *nodes) {
+result_value_ref_t let(arena_t *arena, environment_t *env,
+                       const node_list_t *nodes) {
   assert(nodes->count > 0); // let is always there
   node_t first = listGet(node_t, nodes, 0);
   if (nodes->count != 3) {
@@ -138,7 +141,7 @@ result_value_ref_t let(environment_t *env, const node_list_t *nodes) {
 
     node_t body = listGet(node_t, &couple.value.list, 1);
     value_t *evaluated = nullptr;
-    tryWithCleanup(result_value_ref_t, evaluate(nodes->arena, &body, local_env),
+    tryWithCleanup(result_value_ref_t, evaluate(arena, &body, local_env),
                    environmentDestroy(&local_env), evaluated);
     tryWithCleanupMeta(
         result_value_ref_t,
@@ -149,43 +152,46 @@ result_value_ref_t let(environment_t *env, const node_list_t *nodes) {
   node_t form = listGet(node_t, nodes, 2);
 
   value_t *result = nullptr;
-  tryWithCleanup(result_value_ref_t, evaluate(nodes->arena, &form, local_env),
+  tryWithCleanup(result_value_ref_t, evaluate(arena, &form, local_env),
                  environmentDestroy(&local_env), result);
 
   environmentDestroy(&local_env);
   return ok(result_value_ref_t, result);
 }
 
-const char *COND_EXAMPLE = "(cond\n\t((!= x 0) (/ 10 x))\n\t(+ x 10))";
+const char *COND_EXAMPLE = "\n  (cond\n    ((!= x 0) (/ 10 x))\n    (+ x 10))";
 const char *COND = "cond";
-result_value_ref_t cond(environment_t *env, const node_list_t *nodes) {
+result_value_ref_t cond(arena_t *arena, environment_t *env,
+                        const node_list_t *nodes) {
   assert(nodes->count > 0);
   value_t *result = nullptr;
 
+  size_t offset = arena->offset;
   for (size_t i = 1; i < nodes->count - 1; i++) {
     node_t node = listGet(node_t, nodes, i);
     if (node.type != NODE_TYPE_LIST || node.value.list.count != 2) {
       throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, node.position,
             "%s requires a list of condition-form assignments. %s", COND,
-            LET_EXAMPLE);
+            COND_EXAMPLE);
     }
 
     node_t condition = listGet(node_t, &node.value.list, 0);
-    try(result_value_ref_t, evaluate(nodes->arena, &condition, env), result);
+    try(result_value_ref_t, evaluate(arena, &condition, env), result);
 
     if (result->type != VALUE_TYPE_BOOLEAN) {
       throw(result_value_ref_t, ERROR_CODE_RUNTIME_ERROR, node.position,
-            "Conditions should resolve to a boolean. %s", LET_EXAMPLE);
+            "Conditions should resolve to a boolean. %s", COND_EXAMPLE);
     }
 
     if (result->value.boolean) {
       node_t form = listGet(node_t, &node.value.list, 1);
-      try(result_value_ref_t, evaluate(nodes->arena, &form, env), result);
+      try(result_value_ref_t, evaluate(arena, &form, env), result);
       return ok(result_value_ref_t, result);
     }
+    arena->offset = offset;
   }
 
   node_t fallback = listGet(node_t, nodes, nodes->count - 1);
-  try(result_value_ref_t, evaluate(nodes->arena, &fallback, env), result);
+  try(result_value_ref_t, evaluate(arena, &fallback, env), result);
   return ok(result_value_ref_t, result);
 }

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -1,11 +1,11 @@
 #include "../lib/list.h"
 #include "../lib/map.h"
 #include "../lib/result.h"
-#include "environment.h"
 #include "error.h"
 #include "evaluate.h"
 #include "node.h"
 #include "value.h"
+#include "virtual_machine.h"
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>

--- a/lifp/std/core.c
+++ b/lifp/std/core.c
@@ -10,7 +10,7 @@ result_void_position_t sum(value_t *result, value_list_t *values) {
     value_t current = listGet(value_t, values, i);
     if (current.type != VALUE_TYPE_INTEGER) {
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, current.position,
-            "%s requires a list numbers. Got type %u", SUM, current.type);
+            "%s requires a list of numbers. Got type %u", SUM, current.type);
     }
 
     sum += current.value.integer;

--- a/lifp/std/math.c
+++ b/lifp/std/math.c
@@ -88,7 +88,7 @@ result_void_position_t mathMin(value_t *result, value_list_t *values) {
 }
 
 // Math random function - returns a random integer between 0 and RAND_MAX
-const char *MATH_RANDOM = "math.random";
+const char *MATH_RANDOM = "math.random!";
 result_void_position_t mathRandom(value_t *result, value_list_t *values) {
   if (values->count != 0) {
     throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,

--- a/lifp/value.c
+++ b/lifp/value.c
@@ -1,5 +1,6 @@
 #include "value.h"
 #include "node.h"
+#include <string.h>
 
 result_ref_t valueCreateInit(arena_t *arena, value_type_t type,
                              node_type_t form_type) {
@@ -24,7 +25,7 @@ result_void_t valueInit(value_t *value, arena_t *arena, value_type_t type,
     value_list_t *list = nullptr;
     try(result_void_t, listCreate(value_t, arena, VALUE_LIST_INITIAL_SIZE),
         list);
-    bytewiseCopy(&value->value.list, list, sizeof(value_list_t));
+    memcpy(&value->value.list, list, sizeof(value_list_t));
     arenaAllocationFrameEnd(arena, frame);
   }
 
@@ -33,11 +34,11 @@ result_void_t valueInit(value_t *value, arena_t *arena, value_type_t type,
     value_list_t *list = nullptr;
     try(result_void_t, listCreate(node_t, arena, VALUE_LIST_INITIAL_SIZE),
         list);
-    bytewiseCopy(&value->value.closure.arguments, list, sizeof(value_list_t));
+    memcpy(&value->value.closure.arguments, list, sizeof(value_list_t));
 
     node_t *form = nullptr;
     try(result_void_t, nodeCreate(arena, form_type), form);
-    bytewiseCopy(&value->value.closure.form, form, sizeof(node_t));
+    memcpy(&value->value.closure.form, form, sizeof(node_t));
     arenaAllocationFrameEnd(arena, frame);
   }
 

--- a/lifp/value.h
+++ b/lifp/value.h
@@ -43,5 +43,10 @@ typedef struct value_t {
 
 constexpr size_t VALUE_LIST_INITIAL_SIZE = 8;
 
-result_ref_t valueCreate(arena_t *arena, value_type_t type);
-result_value_ref_t valueClone(arena_t *arena, const value_t *source);
+result_ref_t valueCreateInit(arena_t *arena, value_type_t type,
+                             node_type_t form_type);
+result_void_t valueCopy(value_t *source, value_t *destination,
+                        arena_t *destination_arena);
+result_void_t valueInit(value_t *value, arena_t *arena, value_type_t type,
+                        node_type_t form_type);
+result_ref_t valueCreate(arena_t *arena);

--- a/lifp/virtual_machine.c
+++ b/lifp/virtual_machine.c
@@ -2,7 +2,6 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include "virtual_machine.h"
-#include "../lib/debug.h"
 
 // NOLINTBEGIN
 #include "std/core.c"

--- a/lifp/virtual_machine.h
+++ b/lifp/virtual_machine.h
@@ -10,9 +10,10 @@ typedef struct environment_t {
   struct environment_t *parent;
 } environment_t;
 
-result_void_position_t sum(value_t *result, value_list_t *values);
+result_ref_t vmInit();
 
 result_ref_t environmentCreate(environment_t *parent);
 void environmentDestroy(environment_t **self_ref);
 
-value_t *environmentResolveSymbol(environment_t *self, const char *symbol);
+const value_t *environmentResolveSymbol(environment_t *self,
+                                        const char *symbol);

--- a/tests/arena.test.c
+++ b/tests/arena.test.c
@@ -32,7 +32,7 @@ void overflow() {
   
   result_ref_t allocation = arenaAllocate(arena, 200);
   expectFalse(allocation.code == 0, "fails oversized allocation");
-  expectEqlString(allocation.message, "Arena out of memory. Available 100, requested 200", 64, "throws correct exception");
+  expectEqlString(allocation.message, "Arena 1 out of memory. Available 100, requested 200, total 100", 64, "throws correct exception");
   
   arenaDestroy(&arena);
 }

--- a/tests/arena.test.c
+++ b/tests/arena.test.c
@@ -32,7 +32,7 @@ void overflow() {
   
   result_ref_t allocation = arenaAllocate(arena, 200);
   expectFalse(allocation.code == 0, "fails oversized allocation");
-  expectEqlString(allocation.message, "Arena 1 out of memory. Available 100, requested 200, total 100", 64, "throws correct exception");
+  expectTrue(strstr(allocation.message, "Available 100, requested 200, total 100") != NULL, "throws correct exception");
   
   arenaDestroy(&arena);
 }

--- a/tests/evaluate.test.c
+++ b/tests/evaluate.test.c
@@ -21,36 +21,36 @@ void expectEqlValueType(value_type_t actual, value_type_t expected,
 }
 
 void atoms() {
-  value_t *result = nullptr;
+  value_t result;
 
   case("integer");
   node_t integer_node = nInt(42);
-  tryAssertAssign(evaluate(test_arena, &integer_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_INTEGER,
+  tryAssert(evaluate(&result, test_arena, &integer_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_INTEGER,
                      "has correct type");
-  expectEqlInt(result->value.integer, 42, "has correct value");
+  expectEqlInt(result.value.integer, 42, "has correct value");
 
   case("boolean");
   node_t bool_node = nBool(true);
-  tryAssertAssign(evaluate(test_arena, &bool_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_BOOLEAN,
+  tryAssert(evaluate(&result, test_arena, &bool_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_BOOLEAN,
                      "has correct type");
-  expectTrue(result->value.boolean, "has correct value");
+  expectTrue(result.value.boolean, "has correct value");
 
   case("nil");
   node_t nil_node = nNil();
-  tryAssertAssign(evaluate(test_arena, &nil_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_NIL,
+  tryAssert(evaluate(&result, test_arena, &nil_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_NIL,
                      "has correct type");
 
   case("symbol");
-  value_t *symbol = nullptr;
-  tryAssertAssign(valueCreate(test_arena, VALUE_TYPE_INTEGER), symbol);
-  mapSet(environment->values, "value", symbol);
+  value_t symbol;
+  tryAssert(valueInit(&symbol, test_arena, VALUE_TYPE_INTEGER, 0));
+  mapSet(environment->values, "value", &symbol);
 
   node_t symbol_node = nSym("value");
-  tryAssertAssign(evaluate(test_arena, &symbol_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_INTEGER,
+  tryAssert(evaluate(&result, test_arena, &symbol_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_INTEGER,
                      "has correct type");
 }
 
@@ -65,11 +65,11 @@ void listOfElements() {
 
   node_t list_node = nList(2, expected->data);
 
-  value_t *result = nullptr;
-  tryAssertAssign(evaluate(test_arena, &list_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_LIST,
+  value_t result;
+  tryAssert(evaluate(&result, test_arena, &list_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_LIST,
                      "has correct type");
-  value_list_t reduced_list = result->value.list;
+  value_list_t reduced_list = result.value.list;
   expectEqlSize(reduced_list.count, 2, "has correct count");
   for (size_t i = 0; i < reduced_list.count; i++) {
     value_t node = listGet(value_t, &reduced_list, i);
@@ -96,10 +96,9 @@ void functionCall() {
   node_t form_node = nList(4, list->data);
   form_node.value.list.capacity = list->capacity;
 
-  value_t *result = nullptr;
-  tryAssertAssign(evaluate(test_arena, &form_node, environment), result);
-  expectNotNull(result, "reduced result is not null");
-  expectEqlInt(result->value.integer, 6, "has correct result");
+  value_t result;
+  tryAssert(evaluate(&result, test_arena, &form_node, environment));
+  expectEqlInt(result.value.integer, 6, "has correct result");
   
   value_t val = { .type = VALUE_TYPE_INTEGER, .value.integer = 1};
   mapSet(environment->values, "lol", &val);
@@ -110,8 +109,8 @@ void functionCall() {
   tryAssert(listAppend(node_t, list, &num1))
   node_t list_node = nList(4, list->data);
   form_node.value.list.capacity = list->capacity;
-  tryAssertAssign(evaluate(test_arena, &list_node, environment), result);
-  expectEqlUint(result->type, VALUE_TYPE_LIST, "does't invoke if symbol is not lambda");
+  tryAssert(evaluate(&result, test_arena, &list_node, environment));
+  expectEqlUint(result.type, VALUE_TYPE_LIST, "does't invoke if symbol is not lambda");
 }
 
 void nested() {
@@ -137,13 +136,13 @@ void nested() {
   node_t outer_list_node = nList(2, outer_list->data);
   outer_list_node.value.list.capacity = outer_list->capacity;
 
-  value_t *result = nullptr;
-  tryAssertAssign(evaluate(test_arena, &outer_list_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_LIST,
+  value_t result;
+  tryAssert(evaluate(&result, test_arena, &outer_list_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_LIST,
                      "has correct type");
-  expectEqlSize(result->value.list.count, 2, "has correct count");
-  value_t first = listGet(value_t, &result->value.list, 0);
-  value_t second = listGet(value_t, &result->value.list, 1);
+  expectEqlSize(result.value.list.count, 2, "has correct count");
+  value_t first = listGet(value_t, &result.value.list, 0);
+  value_t second = listGet(value_t, &result.value.list, 1);
   expectEqlValueType(first.type, VALUE_TYPE_INTEGER, "has correct type");
   expectEqlValueType(second.type, VALUE_TYPE_LIST, "has correct type");
 }
@@ -155,21 +154,21 @@ void emptyList() {
   node_t empty_list_node = nList(0, empty_list->data);
   empty_list_node.value.list.capacity = empty_list->capacity;
 
-  value_t *result = nullptr;
-  tryAssertAssign(evaluate(test_arena, &empty_list_node, environment), result);
-  expectEqlValueType(result->type, VALUE_TYPE_LIST, "has correct type");
-  expectEqlSize(result->value.list.count, 0, "has correct count");
+  value_t result;
+  tryAssert(evaluate(&result, test_arena, &empty_list_node, environment));
+  expectEqlValueType(result.type, VALUE_TYPE_LIST, "has correct type");
+  expectEqlSize(result.value.list.count, 0, "has correct count");
 }
 
 void allocations() {
   arena_t *small_arena = nullptr;
   tryAssertAssign(arenaCreate(32), small_arena);
 
-  arenaAllocate(small_arena, 31); // Use up most space
+  arenaAllocate(small_arena, 32); // Use up all space
   node_t large_node = nInt(123);
-  result_value_ref_t reduction = evaluate(small_arena, &large_node, environment);
-  expectEqlInt(reduction.code, ERROR_CODE_ALLOCATION,
-                "returns allocation error");
+  value_t result;
+  auto reduction = evaluate(&result, small_arena, &large_node, environment);
+  expectEqlInt(reduction.code, RESULT_OK, "does not allocate memory on temp arena");
 
   arenaDestroy(&small_arena);
 }
@@ -182,7 +181,8 @@ void errors() {
   node_t sym = nSym("not-existent");
   tryAssert(listAppend(node_t, list, &sym));
 
-  result_value_ref_t reduction = evaluate(test_arena, &sym, environment);
+  value_t result;
+  auto reduction = evaluate(&result, test_arena, &sym, environment);
   expectEqlInt(reduction.code, ERROR_CODE_REFERENCE_SYMBOL_NOT_FOUND, "with correct symbol");
 }
 
@@ -201,7 +201,8 @@ void defSpecialForm() {
   node_t list_node = nList(3, list->data);
   list_node.value.list.arena = test_arena;
 
-  tryAssert(evaluate(test_arena, &list_node, environment));
+  value_t result;
+  tryAssert(evaluate(&result, test_arena, &list_node, environment));
   value_t* val = mapGet(value_t, environment->values, "foo");
 
   expectNotNull(val, "environment is updated");
@@ -245,11 +246,11 @@ void fnSpecialForm() {
   node_t fn_node = nList(3, fn_list->data);
   fn_node.value.list.arena = test_arena;
 
-  value_t *closure;
-  tryAssertAssign(evaluate(test_arena, &fn_node, environment), closure);
-  expectEqlUint(closure->type, VALUE_TYPE_CLOSURE, "creates closure");
-  expectEqlSize(closure->value.closure.arguments.count, 2, "with correct argument count");
-  expectEqlUint(closure->value.closure.form.type, NODE_TYPE_LIST, "with correct form type");
+  value_t closure;
+  tryAssert(evaluate(&closure, test_arena, &fn_node, environment));
+  expectEqlUint(closure.type, VALUE_TYPE_CLOSURE, "creates closure");
+  expectEqlSize(closure.value.closure.arguments.count, 2, "with correct argument count");
+  expectEqlUint(closure.value.closure.form.type, NODE_TYPE_LIST, "with correct form type");
  
   case("not using symbols for arguments");
   node_list_t *fn_no_symbol = nullptr;
@@ -268,7 +269,8 @@ void fnSpecialForm() {
   tryAssert(listAppend(node_t, fn_no_symbol, &body_x));
 
   fn_node.value.list.data = fn_no_symbol->data;
-  result_value_ref_t evaluation = evaluate(test_arena, &fn_node, environment);
+  value_t result;
+  auto evaluation = evaluate(&result, test_arena, &fn_node, environment);
   expectEqlInt(evaluation.code, ERROR_CODE_RUNTIME_ERROR, "throws a syntax error"); 
   
   case("not using lists for arguments");
@@ -281,7 +283,7 @@ void fnSpecialForm() {
   tryAssert(listAppend(node_t, fn_bad_bindings, &body_x));
 
   fn_node.value.list.data = fn_bad_bindings->data;
-  evaluation = evaluate(test_arena, &fn_node, environment);
+  evaluation = evaluate(&result, test_arena, &fn_node, environment);
   expectEqlInt(evaluation.code, ERROR_CODE_RUNTIME_ERROR, "throws a syntax error"); 
 }
 
@@ -342,10 +344,10 @@ void letSpecialForm() {
   node_t let_node = nList(3, let_list->data);
   let_node.value.list.arena = test_arena;
 
-  value_t* let;
-  tryAssertAssign(evaluate(test_arena, &let_node, environment), let);
-  expectEqlUint(let->type, VALUE_TYPE_INTEGER, "evaluates to integer");
-  expectEqlInt(let->value.integer, 15, "with correct result (5 + 10)");
+  value_t let;
+  tryAssert(evaluate(&let, test_arena, &let_node, environment));
+  expectEqlUint(let.type, VALUE_TYPE_INTEGER, "evaluates to integer");
+  expectEqlInt(let.value.integer, 15, "with correct result (5 + 10)");
 
   // Verify that let bindings don't leak to outer environment
   value_t* leaked_a = mapGet(value_t, environment->values, "a");
@@ -374,10 +376,10 @@ void condSpecialForm() {
   tryAssert(listAppend(node_t, &cond->value.list, true_clause));
   tryAssert(listAppend(node_t, &cond->value.list, &fallback_value));
 
-  value_t *result = nullptr;
-  tryAssertAssign(evaluate(test_arena, cond, environment), result);
-  expectEqlUint(result->type, VALUE_TYPE_INTEGER, "returns integer");
-  expectEqlInt(result->value.integer, true_value.value.integer, "evaluates true clause");
+  value_t result;
+  tryAssert(evaluate(&result, test_arena, cond, environment));
+  expectEqlUint(result.type, VALUE_TYPE_INTEGER, "returns integer");
+  expectEqlInt(result.value.integer, true_value.value.integer, "evaluates true clause");
 
   tryAssertAssign(nodeCreate(test_arena, NODE_TYPE_LIST), cond);
   
@@ -390,9 +392,9 @@ void condSpecialForm() {
   tryAssert(listAppend(node_t, &cond->value.list, false_clause));
   tryAssert(listAppend(node_t, &cond->value.list, &fallback_value));
 
-  tryAssertAssign(evaluate(test_arena, cond, environment), result);
-  expectEqlUint(result->type, VALUE_TYPE_INTEGER, "returns integer");
-  expectEqlInt(result->value.integer, fallback_value.value.integer, "evaluates fallback clause");
+  tryAssert(evaluate(&result, test_arena, cond, environment));
+  expectEqlUint(result.type, VALUE_TYPE_INTEGER, "returns integer");
+  expectEqlInt(result.value.integer, fallback_value.value.integer, "evaluates fallback clause");
 
   // (cond (false 42) (true 42) 99)
   tryAssertAssign(nodeCreate(test_arena, NODE_TYPE_LIST), cond);
@@ -402,9 +404,9 @@ void condSpecialForm() {
   tryAssert(listAppend(node_t, &cond->value.list, true_clause));
   tryAssert(listAppend(node_t, &cond->value.list, &fallback_value));
 
-  tryAssertAssign(evaluate(test_arena, cond, environment), result);
-  expectEqlUint(result->type, VALUE_TYPE_INTEGER, "returns integer");
-  expectEqlInt(result->value.integer, 42, "evaluates the first true clause");
+  tryAssert(evaluate(&result, test_arena, cond, environment));
+  expectEqlUint(result.type, VALUE_TYPE_INTEGER, "returns integer");
+  expectEqlInt(result.value.integer, 42, "evaluates the first true clause");
 }
 
 int main(void) {

--- a/tests/evaluate.test.c
+++ b/tests/evaluate.test.c
@@ -409,7 +409,7 @@ void condSpecialForm() {
 
 int main(void) {
   tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), test_arena);
-  tryAssertAssign(environmentCreate(nullptr), environment);
+  tryAssertAssign(vmInit(), environment);
 
   suite(atoms);
   suite(listOfElements);

--- a/tests/evaluate.test.c
+++ b/tests/evaluate.test.c
@@ -1,9 +1,9 @@
 #include "../lifp/evaluate.h"
 #include "../lib/arena.h"
 #include "../lib/list.h"
-#include "../lifp/environment.h"
 #include "../lifp/error.h"
 #include "../lifp/node.h"
+#include "../lifp/virtual_machine.h"
 #include "test.h"
 #include "utils.h"
 #include <assert.h>

--- a/tests/fmt.test.c
+++ b/tests/fmt.test.c
@@ -40,7 +40,7 @@ void values() {
   offset = 0;
   arenaReset(test_arena);
   value_t *list = nullptr;
-  tryAssertAssign(valueCreate(test_arena, VALUE_TYPE_LIST), list);
+  tryAssertAssign(valueCreateInit(test_arena, VALUE_TYPE_LIST, 0), list);
 
   tryAssert(listAppend(value_t, &list->value.list, &integer));
   tryAssert(listAppend(value_t, &list->value.list, &nil));
@@ -51,7 +51,8 @@ void values() {
   offset = 0;
   arenaReset(test_arena);
   value_t *closure = nullptr;
-  tryAssertAssign(valueCreate(test_arena, VALUE_TYPE_CLOSURE), closure);
+  tryAssertAssign(
+      valueCreateInit(test_arena, VALUE_TYPE_CLOSURE, NODE_TYPE_LIST), closure);
 
   node_t *symbol = nullptr;
   tryAssertAssign(nodeCreate(test_arena, NODE_TYPE_SYMBOL), symbol);

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -19,7 +19,7 @@ result_value_ref_t execute(const char *input) {
   result_value_ref_t last_result;
 
   environment_t *env = nullptr;
-  tryAssertAssign(environmentCreate(nullptr), env);
+  tryAssertAssign(vmInit(), env);
 
   while (line != NULL) {
     token_list_t *tokens = nullptr;

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -8,75 +8,89 @@
 #include <assert.h>
 #include <stddef.h>
 
-static arena_t *test_ast_arena;
-static arena_t *test_temp_arena;
+static arena_t *ast_arena;
+static arena_t *temp_arena;
 
-result_value_ref_t execute(const char *input) {
+void execute(value_t *result, const char *input) {
   char input_copy[1024];
   strcpy(input_copy, input);
 
   char *line = strtok(input_copy, "\n");
-  result_value_ref_t last_result;
 
-  environment_t *env = nullptr;
-  tryAssertAssign(vmInit(), env);
+  environment_t *global_environment = nullptr;
+  tryAssertAssign(vmInit(), global_environment);
 
   while (line != NULL) {
+    arenaReset(ast_arena);
+    arenaReset(temp_arena);
     token_list_t *tokens = nullptr;
-    tryAssertAssign(tokenize(test_ast_arena, line), tokens);
+    tryAssertAssign(tokenize(ast_arena, line), tokens);
 
     size_t offset = 0;
     size_t depth = 0;
-    node_t *syntax_tree = nullptr;
-    tryAssertAssign(parse(test_ast_arena, tokens, &offset, &depth),
-                    syntax_tree);
+    node_t *ast = nullptr;
+    tryAssertAssign(parse(ast_arena, tokens, &offset, &depth), ast);
 
-    result_value_ref_t reduction = evaluate(test_temp_arena, syntax_tree, env);
-    assert(reduction.code == RESULT_OK);
-    last_result = reduction;
+    value_t res;
+    auto reduction = evaluate(&res, temp_arena, ast, global_environment);
+    if (reduction.code != RESULT_OK) {
+      printf("Reduction error: %s\n", reduction.message);
+      assert(reduction.code == RESULT_OK);
+    }
 
     line = strtok(nullptr, "\n");
-    arenaReset(test_ast_arena);
+    *result = res;
   }
 
-  environmentDestroy(&env);
-  arenaReset(test_temp_arena);
-  return last_result;
+  environmentDestroy(&global_environment);
 }
 
 int main() {
-  tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), test_ast_arena);
-  tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), test_temp_arena);
+  tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), ast_arena);
+  tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), temp_arena);
 
   case("number");
-  result_value_ref_t reduction = execute("1");
-  expectEqlInt(reduction.value->value.integer, 1, "returns correct value");
-
+  value_t number;
+  execute(&number, "1");
+  expectEqlInt(number.value.integer, 1, "returns correct value");
+  
   case("symbol");
-  reduction = execute("+");
-  expectNotNull(reduction.value->value.builtin, "returns correct value");
-
+  value_t symbol;
+  execute(&symbol, "+");
+  expectNotNull(symbol.value.builtin, "returns correct value");
+  
   case("list");
-  reduction = execute("(1 2)");
-  expectEqlUint((unsigned int)reduction.value->value.list.count, 2, "returns a list"); 
-  value_t first = listGet(value_t, &reduction.value->value.list,  0); 
+  value_t list;
+  execute(&list, "(1 2)");
+  expectEqlUint((unsigned int)list.value.list.count, 2, "returns a list"); 
+  value_t first = listGet(value_t, &list.value.list,  0); 
   expectEqlInt(first.value.integer, 1, "correct first item"); 
-  value_t second = listGet(value_t, &reduction.value->value.list, 1);
+  value_t second = listGet(value_t, &list.value.list, 1);
   expectEqlInt(second.value.integer, 2, "correct second item");
-
+  
   case("simple form");
-  reduction = execute("(+ 1 2)");
-  expectEqlInt(reduction.value->value.integer, 3, "returns correct value");
-
+  value_t simple;
+  execute(&simple, "(+ 1 2)");
+  expectEqlInt(simple.value.integer, 3, "returns correct value");
+  
   case("nested form");
-  reduction = execute("(+ 1 (+ 2 4))");
-  expectEqlInt(reduction.value->value.integer, 7, "returns correct value");
-
+  value_t nested;
+  execute(&nested, "(+ 1 (+ 2 4))");
+  expectEqlInt(nested.value.integer, 7, "returns correct value");
+  
   case("declare function");
-  reduction = execute("(def! sum (fn (a b) (+ a b)))\n(sum 1 2)");
-  expectEqlInt(reduction.value->value.integer, 3, "returns correct value");
+  value_t fun;
+  execute(&fun, "(def! sum (fn (a b) (+ a b)))\n(sum 1 2)");
+  expectEqlUint(fun.type, VALUE_TYPE_INTEGER, "returns correct type");
+  expectEqlInt(fun.value.integer, 3, "returns correct value");
+  
+  case("let");
+  value_t let;
+  execute(&let, "(let ((plus (fn (x y) (+ x y))) (a 1)) (plus a 1))");
+  expectEqlUint(let.type, VALUE_TYPE_INTEGER, "returns correct type");
+  expectEqlInt(let.value.integer, 2, "returns correct value");
 
-  arenaDestroy(&test_ast_arena);
-  arenaDestroy(&test_temp_arena);
+  arenaDestroy(&ast_arena);
+  arenaDestroy(&temp_arena);
   return report();
 }

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -90,6 +90,43 @@ int main() {
   expectEqlUint(let.type, VALUE_TYPE_INTEGER, "returns correct type");
   expectEqlInt(let.value.integer, 2, "returns correct value");
 
+  case("conditional - cond special form");
+  value_t cond_test;
+  execute(&cond_test, "(cond ((< 5 3) 1) ((> 5 3) 2) (3))");
+  expectEqlInt(cond_test.value.integer, 2, "evaluates correct branch");
+
+  case("boolean operations");
+  value_t bool_test;
+  execute(&bool_test, "(and (= 1 1) (> 5 3))");
+  expectEqlUint(bool_test.type, VALUE_TYPE_BOOLEAN, "returns boolean type");
+  expectTrue(bool_test.value.boolean, "logical and works");
+
+  case("recursive function calls");
+  value_t factorial;
+  execute(&factorial, "(def! fact (fn (n) (cond ((< n 1) 1) (* n (fact (- n 1))))))\n(fact 5)");
+  expectEqlInt(factorial.value.integer, 120, "recursive factorial works");
+
+  case("empty list and nil handling");
+  value_t empty_list;
+  execute(&empty_list, "()");
+  expectEqlUint(empty_list.type, VALUE_TYPE_LIST, "empty list has correct type");
+  expectEqlUint((unsigned int)empty_list.value.list.count, 0, "empty list has zero elements");
+
+  case("variable shadowing in nested let");
+  value_t shadow_test;
+  execute(&shadow_test, "(let ((x 1)) (let ((x 2)) x))");
+  expectEqlInt(shadow_test.value.integer, 2, "inner binding shadows outer");
+
+  case("multiple expressions with side effects");
+  value_t multi_expr;
+  execute(&multi_expr, "(def! x 1)\n(def! x (+ x 1))\nx");
+  expectEqlInt(multi_expr.value.integer, 2, "sequential definitions work");
+
+  case("function parameter shadowing");
+  value_t shadow_param;
+  execute(&shadow_param, "(def! x 10)\n(def! test (fn (x) (+ x 1)))\n(test 5)");
+  expectEqlInt(shadow_param.value.integer, 6, "function parameter shadows global variable");
+
   arenaDestroy(&ast_arena);
   arenaDestroy(&temp_arena);
   return report();

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -213,7 +213,7 @@ int main(void) {
 #include <stdio.h>
 
 int main(void) {
-  printf("Error: This test can only with PROFILE=1\n"
+  printf("Error: This test can only run with PROFILE=1\n"
          "  Run again with:\n"
          "    make PROFILE=1 clean tests/memory.test && tests/memory.test\n");
 

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -9,12 +9,15 @@
 #include "utils.h"
 
 #include <stddef.h>
+#include <string.h>
 allocMetricsInit();
 
 static arena_t *test_ast_arena;
 static arena_t *test_temp_arena;
 static environment_t *global;
 
+// This execute function does stack allocations, hence why we expect no
+// allocations in the following tests
 void execute(const char *input) {
   char input_copy[1024];
   strcpy(input_copy, input);
@@ -48,6 +51,130 @@ size_t getUsedArenas(void) {
   return arena_metrics.arenas_count - freed;
 }
 
+size_t getTotalAllocatedBytes(void) { return allocGetMetrics().bytes; }
+
+size_t getArenaMemoryUsage(arena_t *arena) { return arena->offset; }
+
+void transientAllocations(void) {
+  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+
+  execute("(+ 1 2 3)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after simple invocation");
+
+  execute("(def! add (fn (a b) (+ a b)))");
+  execute("(add 10 20)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after closure invocation");
+
+  execute("(+ (+ 1 2) (+ 3 4))");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after nested evaluations");
+
+  execute("(1 2 3 4 5)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after list evaluation");
+
+  arenaReset(test_ast_arena);
+  arenaReset(test_temp_arena);
+}
+
+void letBindingsMemory(void) {
+  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+
+  execute("(let ((x 10) (y 20)) (+ x y))");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after let binding");
+
+  execute("(let ((x 1)) (let ((y 2)) (+ x y)))");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after nested let bindings");
+
+  execute("(let ((f (fn (a) (+ a 1)))) (f 10))");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after let with closures");
+
+  arenaReset(test_ast_arena);
+  arenaReset(test_temp_arena);
+}
+
+void conditionalMemory(void) {
+  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+
+  execute("(cond ((= 1 1) 42) 0)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after conditional");
+
+  execute("(cond ((= 1 2) (+ 1 2)) ((= 2 2) (+ 3 4)) (+ 5 6))");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after multiple conditions");
+
+  execute("(cond ((= 1 1) (let ((x 10)) x)) 0)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after conditional with let");
+
+  arenaReset(test_ast_arena);
+  arenaReset(test_temp_arena);
+}
+
+void closureMemory(void) {
+  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+
+  execute("(def! multiply (fn (a b) (* a b)))");
+  size_t after_def_temp = getArenaMemoryUsage(test_temp_arena);
+
+  execute("(multiply 5 6)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), after_def_temp,
+                "cleans arena after closure invocation");
+
+  execute("(multiply 1 2)");
+  execute("(multiply 3 4)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), after_def_temp,
+                "cleans arena after multiple closure invocations");
+
+  execute("(def! complex (fn (x) (let ((y (+ x 1))) (cond ((= y 5) y) x))))");
+  execute("(complex 4)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after complex closure");
+}
+
+void recursiveMemory(void) {
+  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+
+  execute("(def! countdown (fn (n) (cond ((= n 0) 0) (countdown (- n 1)))))");
+  execute("(countdown 5)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after recursive calls");
+
+  execute("(countdown 20)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after deep recursion");
+}
+
+void errorHandlingMemory(void) {
+  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t initial_safe_alloc = getTotalAllocatedBytes();
+
+  execute("(def! add2 (fn (a b) (+ a b)))");
+  execute("(add2 1)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after arity error");
+  expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
+                "no memory leaks from arity error");
+
+  execute("undefined");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after undefined symbol error");
+  expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
+                "no memory leaks from undefined symbol error");
+
+  execute("(let ((x undefined_var)) x)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after let binding error");
+  expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
+                "no memory leaks from let binding error");
+}
+
 void danglingArenas(void) {
   execute("((fn (a) a) 1 2)");
   expectEqlSize(getUsedArenas(), 3, "no dangling arena on failure");
@@ -66,6 +193,12 @@ int main(void) {
 
   profileInit();
 
+  suite(transientAllocations);
+  suite(letBindingsMemory);
+  suite(conditionalMemory);
+  suite(closureMemory);
+  suite(recursiveMemory);
+  suite(errorHandlingMemory);
   suite(danglingArenas);
 
   return report();

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -168,6 +168,12 @@ void errorHandlingMemory(void) {
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from undefined symbol error");
 
+  execute("((fn (1) a) 1)");
+  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+                "cleans arena after invalid closure invocation");
+  expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
+                "no memory leaks from invalid closure");
+
   execute("(let ((x undefined_var)) x)");
   expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
                 "cleans arena after let binding error");

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -68,7 +68,7 @@ void danglingArenas(void) {
 int main(void) {
   tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), test_ast_arena);
   tryAssertAssign(arenaCreate((size_t)(1024 * 1024)), test_temp_arena);
-  tryAssertAssign(environmentCreate(nullptr), global);
+  tryAssertAssign(vmInit(), global);
 
   profileInit();
 
@@ -77,6 +77,8 @@ int main(void) {
   return report();
 }
 #else
+#include <stdio.h>
+
 int main(void) {
   printf("Error: This test can only with PROFILE=1\n"
          "  Run again with:\n"

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -2,10 +2,10 @@
 #include "../lib/arena.h"
 #include "../lib/profile.h"
 #include "../lib/result.h"
-#include "../lifp/environment.h"
 #include "../lifp/evaluate.h"
 #include "../lifp/parse.h"
 #include "../lifp/tokenize.h"
+#include "../lifp/virtual_machine.h"
 #include "test.h"
 #include "utils.h"
 


### PR DESCRIPTION
## TODO
- [X] Somehow latest changes broke release builds (code with -O0 and with -O2 behaves differently)
- [x] New methods are undocumented 
- [x] ~We should give TCO a shot~ In another change, this is getting too beefy.


This PR was born from the consideration that we cannot run the simplest fibonacci code in 64kb after a couple of numbers (it died at `(fibonacci 3)`).

### Memory
The biggest change is introducing allocation frames. An allocation frame is a region in the arena where we write scratch values we need for a shorter lifetime than the arena's itself.
It becomes particularly useful for recursive calls, where the temporary memory keeps growing at each recursive step, but we effectively don't need the first values ever again.

```
Before:

At every step we allocate some memory in temp_arena. 
Each value is only functional to the next step and the one after, 
we never use it again from that point on.

             0 1 2 3 4 5 6 7 8 9 a b
temp_arena: |1 1 1 . . . . . . . . . |  Step 1
            |1 1 1 2 2 2 . . . . . . |  Step 2
            |1 1 1 2 2 2 3 3 3 . . . |  Step 3

            At each recursive step we accumulate memory, 
            but we only ever return from 333

After:

We mark 0 as the beginning of the allocation frame, and at every 
iteration we rewrite on the same frame.

             0 1 2 3 4 5 6 7 8 9 a b
temp_arena: |1 1 1 . . . . . . . . . | Step 1
            |2 2 2 . . . . . . . . . | Step 2
            |3 3 3 . . . . . . . . . | Step 3            
```


I am not entirely happy, because it feels like shoehorning an arena where I should be using a different allocator.

### Messages
Increased the size of the `message_t` type to 128 bytes to support longer error messages

### Lists
There is now a list `unshift` to pop from the beginning of the list. En passant, I started replacing our homegrown `bytewiseCopy` with string functions, because asan instruments them and our implementation was hiding errors.

### Error Handling
Refactored error handling macros and introduced `tryCatch` and `tryFinally` to execute some cleanup respectively when a function throws or in any case (success or failure). Similar to the same functionality in, for example, JavaScript

### VM
Replaces environment with VM, which is right now not doing much more than environments besides statically pointing at core functions, instead of copying them in every environment.