### PR TITLE
refactor: drop scratch memory optimizations

### DIFF
--- a/.todo
+++ b/.todo
@@ -1,7 +1,6 @@
 BUGS
 ---
   * [ ] `listGet` allows you to go out of bound
-  * [ ]  Nesting lists yields to a format stack overflow (example: `((1) 2)` in the repl)
 
 FEATURES
 ---
@@ -15,7 +14,8 @@ FEATURES
   * [ ] Tail call optimization
   * [ ] Auto-generated documentation for standard library
   * [ ] Enum to text for error messages
-  * [ ] Currying: `(def! make-adder (fn (x) (fn (y) (+ x y))))\n(make-adder 5)` currently loses context on `x` because of immediate invocation
+  * [ ] Currying: `(def! make-adder (fn (x) (fn (y) (+ x y))))\n(make-adder 5)` 
+        currently loses context on `x` because of immediate invocation
   * [ ] Implement `?` in REPL
   * [ ] imports `(import! my-module "./my-module.lifp")
   * [ ] Type Declaration comments `;; (number, number) -> number`

--- a/.todo
+++ b/.todo
@@ -20,6 +20,7 @@ FEATURES
   * [ ] imports `(import! my-module "./my-module.lifp")
   * [ ] Type Declaration comments `;; (number, number) -> number`
   * [ ] Max Call Stack size
+  * [ ] Run should skip comments and allow top-level atoms
 
 REFACTORING
 ---

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ bin/lifp: \
 	lib/arena.o lifp/virtual_machine.o lib/map.o lib/profile.o lifp/fmt.o \
 	lifp/value.o lifp/specials.o linenoise.o args.o
 
+.PHONY: run
+repl: bin/lifp
+	@bin/lifp repl
 
 .PHONY: clean
 clean:

--- a/bin/lifp.c
+++ b/bin/lifp.c
@@ -123,8 +123,8 @@ int main(int argc, char **argv) {
   ap_set_helptext(run_parser, run_help);
   ap_set_version(run_parser, version);
   ap_add_int_opt(run_parser, "file-size f", 1024);
-  ap_add_int_opt(run_parser, "ast-memory a", 64);
-  ap_add_int_opt(run_parser, "temp-memory t", 64);
+  ap_add_int_opt(run_parser, "ast-memory a", 128);
+  ap_add_int_opt(run_parser, "temp-memory t", 128);
 
   ap_set_cmd_callback(run_parser, runCallback);
 
@@ -138,8 +138,8 @@ int main(int argc, char **argv) {
   ap_set_helptext(repl_parser, repl_help);
   ap_set_version(repl_parser, version);
   ap_add_int_opt(repl_parser, "output-size o", 4096);
-  ap_add_int_opt(repl_parser, "ast-memory a", 64);
-  ap_add_int_opt(repl_parser, "temp-memory t", 64);
+  ap_add_int_opt(repl_parser, "ast-memory a", 128);
+  ap_add_int_opt(repl_parser, "temp-memory t", 128);
 
   ap_set_cmd_callback(repl_parser, replCallback);
 

--- a/cmd/repl.c
+++ b/cmd/repl.c
@@ -132,6 +132,7 @@ int repl(const repl_opts_t OPTIONS) {
   }
   profileEnd();
   environmentDestroy(&global_environment);
+  arenaDestroy(&result_arena);
   arenaDestroy(&scratch_arena);
   arenaDestroy(&ast_arena);
   return 0;

--- a/cmd/repl.c
+++ b/cmd/repl.c
@@ -63,8 +63,8 @@ int repl(const repl_opts_t OPTIONS) {
   tryCLI(arenaCreate(OPTIONS.ast_memory), ast_arena,
          "unable to allocate interpreter memory");
 
-  arena_t *temp_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), temp_arena,
+  arena_t *scratch_arena = nullptr;
+  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), scratch_arena,
          "unable to allocate transient memory");
 
   arena_t *result_arena = nullptr;
@@ -85,7 +85,7 @@ int repl(const repl_opts_t OPTIONS) {
   while (true) {
     profileReport();
     arenaReset(ast_arena);
-    arenaReset(temp_arena);
+    arenaReset(scratch_arena);
     char *input = linenoise("> ");
 
     if (!input)
@@ -121,8 +121,8 @@ int repl(const repl_opts_t OPTIONS) {
     tryREPL(parse(ast_arena, tokens, &offset, &depth), ast);
 
     value_t result;
-    tryREPL(
-        evaluate(&result, result_arena, temp_arena, ast, global_environment));
+    tryREPL(evaluate(&result, result_arena, scratch_arena, ast,
+                     global_environment));
 
     int buffer_offset = 0;
     formatValue(&result, (int)OPTIONS.output_size, buffer, &buffer_offset);
@@ -132,7 +132,7 @@ int repl(const repl_opts_t OPTIONS) {
   }
   profileEnd();
   environmentDestroy(&global_environment);
-  arenaDestroy(&temp_arena);
+  arenaDestroy(&scratch_arena);
   arenaDestroy(&ast_arena);
   return 0;
 }

--- a/cmd/repl.c
+++ b/cmd/repl.c
@@ -64,11 +64,11 @@ int repl(const repl_opts_t OPTIONS) {
          "unable to allocate interpreter memory");
 
   arena_t *scratch_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), scratch_arena,
+  tryCLI(arenaCreate(OPTIONS.temp_memory), scratch_arena,
          "unable to allocate transient memory");
 
   arena_t *result_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), result_arena,
+  tryCLI(arenaCreate(OPTIONS.temp_memory), result_arena,
          "unable to allocate transient memory");
 
   environment_t *global_environment = nullptr;

--- a/cmd/repl.c
+++ b/cmd/repl.c
@@ -64,7 +64,11 @@ int repl(const repl_opts_t OPTIONS) {
          "unable to allocate interpreter memory");
 
   arena_t *temp_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory), temp_arena,
+  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), temp_arena,
+         "unable to allocate transient memory");
+
+  arena_t *result_arena = nullptr;
+  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), result_arena,
          "unable to allocate transient memory");
 
   environment_t *global_environment = nullptr;
@@ -117,7 +121,8 @@ int repl(const repl_opts_t OPTIONS) {
     tryREPL(parse(ast_arena, tokens, &offset, &depth), ast);
 
     value_t result;
-    tryREPL(evaluate(&result, temp_arena, ast, global_environment));
+    tryREPL(
+        evaluate(&result, result_arena, temp_arena, ast, global_environment));
 
     int buffer_offset = 0;
     formatValue(&result, (int)OPTIONS.output_size, buffer, &buffer_offset);

--- a/cmd/run.c
+++ b/cmd/run.c
@@ -102,7 +102,11 @@ int run(const run_opts_t OPTIONS) {
          "unable to allocate interpreter memory");
 
   arena_t *temp_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory), temp_arena,
+  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), temp_arena,
+         "unable to allocate transient memory");
+
+  arena_t *result_arena = nullptr;
+  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), result_arena,
          "unable to allocate transient memory");
 
   environment_t *global_environment = nullptr;
@@ -126,7 +130,8 @@ int run(const run_opts_t OPTIONS) {
     tryRun(parse(ast_arena, tokens, &line_offset, &depth), syntax_tree);
 
     value_t reduced;
-    tryRun(evaluate(&reduced, temp_arena, syntax_tree, global_environment));
+    tryRun(evaluate(&reduced, result_arena, temp_arena, syntax_tree,
+                    global_environment));
   } while (strlen(line_buffer) > 0);
 
   profileReport();

--- a/cmd/run.c
+++ b/cmd/run.c
@@ -102,11 +102,11 @@ int run(const run_opts_t OPTIONS) {
          "unable to allocate interpreter memory");
 
   arena_t *scratch_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), scratch_arena,
+  tryCLI(arenaCreate(OPTIONS.temp_memory), scratch_arena,
          "unable to allocate transient memory");
 
   arena_t *result_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), result_arena,
+  tryCLI(arenaCreate(OPTIONS.temp_memory), result_arena,
          "unable to allocate transient memory");
 
   environment_t *global_environment = nullptr;

--- a/cmd/run.c
+++ b/cmd/run.c
@@ -137,6 +137,7 @@ int run(const run_opts_t OPTIONS) {
   profileReport();
 
   environmentDestroy(&global_environment);
+  arenaDestroy(&result_arena);
   arenaDestroy(&scratch_arena);
   arenaDestroy(&ast_arena);
   return 0;

--- a/cmd/run.c
+++ b/cmd/run.c
@@ -101,8 +101,8 @@ int run(const run_opts_t OPTIONS) {
   tryCLI(arenaCreate(OPTIONS.ast_memory), ast_arena,
          "unable to allocate interpreter memory");
 
-  arena_t *temp_arena = nullptr;
-  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), temp_arena,
+  arena_t *scratch_arena = nullptr;
+  tryCLI(arenaCreate(OPTIONS.temp_memory / 2), scratch_arena,
          "unable to allocate transient memory");
 
   arena_t *result_arena = nullptr;
@@ -115,7 +115,7 @@ int run(const run_opts_t OPTIONS) {
   do {
     memset(line_buffer, 0, (size_t)len);
     arenaReset(ast_arena);
-    arenaReset(temp_arena);
+    arenaReset(scratch_arena);
     readLine(len, line_buffer, file_buffer, &file_offset);
 
     if (strlen(line_buffer) == 0)
@@ -130,14 +130,14 @@ int run(const run_opts_t OPTIONS) {
     tryRun(parse(ast_arena, tokens, &line_offset, &depth), syntax_tree);
 
     value_t reduced;
-    tryRun(evaluate(&reduced, result_arena, temp_arena, syntax_tree,
+    tryRun(evaluate(&reduced, result_arena, scratch_arena, syntax_tree,
                     global_environment));
   } while (strlen(line_buffer) > 0);
 
   profileReport();
 
   environmentDestroy(&global_environment);
-  arenaDestroy(&temp_arena);
+  arenaDestroy(&scratch_arena);
   arenaDestroy(&ast_arena);
   return 0;
 }

--- a/examples/fact.lifp
+++ b/examples/fact.lifp
@@ -2,4 +2,4 @@
 
 (io.print! (fact 50))
 
-; vim syntax=lisp
+; vim:ft=lisp

--- a/examples/fibonacci.lifp
+++ b/examples/fibonacci.lifp
@@ -13,4 +13,4 @@
 
 (io.print! (fibonacci 30))
 
-; vim syntax=lisp
+; vim:ft=lisp

--- a/examples/fibonacci.lifp
+++ b/examples/fibonacci.lifp
@@ -1,7 +1,5 @@
 ; This example is here to show how poorly we handle tail recursion
-; (not at all!) so anything more than `(fibonacci 3)` with the
-; default memory (64kb for parsing and 32kb per environment) will
-; crash
+; (not at all!)
 
 (def! fibonacci
   (fn (a)
@@ -11,6 +9,6 @@
       ((= a 2) 2)
       (+ (fibonacci (- a 1)) (fibonacci (- a 2))))))
 
-(io.print! (fibonacci 30))
+(io.print! (fibonacci 8))
 
 ; vim:ft=lisp

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -106,40 +106,6 @@ result_ref_t arenaCreate(size_t size);
 result_ref_t arenaAllocate(arena_t *self, size_t size);
 
 /**
- * Marks the start of an allocation frame in the given arena.
- * An allocation frame is a region in an arena which needs recycling before the
- * arena's end of life.
- *
- * Frames can be nested, but ending a frame within another frame will leads to
- * errors.
- *
- * @param {arena_t*} self - Pointer to the arena instance.
- * @returns {frame_handle_t} A handle pointing to the frame, which can be used
- * to restore the arena to this state later.
- * @example
- *    frame_handle_t frame = arenaAllocationFrameStart(arena);
- *    // .. do the thing
- *    arenaAllocationFrameEnd(frame);
- */
-frame_handle_t arenaAllocationFrameStart(arena_t *self);
-
-/**
- * Ends the allocation frame for the specified arena.
- * All allocations made since the corresponding frame start may be released
- * or invalidated. See `arenaAllocationFrameStart` for details.
- *
- * @param {arena_t*} self - Pointer to the arena instance.
- * @param {frame_handle_t} frame_handle - A handle to the frame to end.
- * @returns {frame_handle_t} A handle pointing to the frame, which can be used
- * to restore the arena to this state later.
- * @example
- *    frame_handle_t frame = arenaAllocationFrameStart(arena);
- *    // .. do the thing
- *    arenaAllocationFrameEnd(frame);
- */
-void arenaAllocationFrameEnd(arena_t *self, frame_handle_t frame_handle);
-
-/**
  * Destroy the arena and free all its memory.
  * @name arenaDestroy
  * @param {arena_t*} self - Pointer to the arena to destroy

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -72,13 +72,14 @@ invokeClosure(value_t *result, value_list_t *evaluated, value_t closure_value,
 }
 
 typedef Result(value_list_t *, position_t) result_value_list_t;
-static result_value_list_t evaluateNodes(arena_t *temp_arena, node_t *ast,
+static result_value_list_t evaluateNodes(arena_t *scratch_arena, node_t *ast,
                                          environment_t *env,
                                          value_t *first_value) {
   const auto list = ast->value.list;
   value_list_t *evaluated;
-  tryWithMeta(result_value_list_t, listCreate(value_t, temp_arena, list.count),
-              ast->position, evaluated);
+  tryWithMeta(result_value_list_t,
+              listCreate(value_t, scratch_arena, list.count), ast->position,
+              evaluated);
 
   // Just for the sake of not re-evaluating the first value
   tryWithMeta(result_value_list_t, listAppend(value_t, evaluated, first_value),
@@ -88,7 +89,7 @@ static result_value_list_t evaluateNodes(arena_t *temp_arena, node_t *ast,
     auto node = listGet(node_t, &list, i);
     value_t reduced;
     try(result_value_list_t,
-        evaluate(&reduced, temp_arena, temp_arena, &node, env));
+        evaluate(&reduced, scratch_arena, scratch_arena, &node, env));
     tryWithMeta(result_value_list_t, listAppend(value_t, evaluated, &reduced),
                 node.position);
   }

--- a/lifp/evaluate.h
+++ b/lifp/evaluate.h
@@ -5,5 +5,15 @@
 #include "value.h"
 #include "virtual_machine.h"
 
-result_void_position_t evaluate(value_t *result, arena_t *temp_arena,
-                                node_t *ast, environment_t *env);
+// Evaluate a node in the context of a given environment.
+//
+// The result arena is where all the values required for the result will be
+// stored. This is where values that need to survive across `evaluate` calls
+// need to be stored.
+//
+// The scratch arena is used for intermediate allocations and it's expected to
+// be wiped at the end of each call. No values to be persisted should be stored
+// there.
+result_void_position_t evaluate(value_t *result, arena_t *result_arena,
+                                arena_t *scratch_arena, node_t *ast,
+                                environment_t *env);

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -50,7 +50,8 @@ result_void_position_t define(value_t *result, arena_t *temp_arena,
   // Perform reduction in the temporary memory
   value_t reduced;
   node_t value = listGet(node_t, nodes, 2);
-  tryCatch(result_void_position_t, evaluate(&reduced, temp_arena, &value, env),
+  tryCatch(result_void_position_t,
+           evaluate(&reduced, temp_arena, temp_arena, &value, env),
            arenaAllocationFrameEnd(temp_arena, frame));
 
   // If reduction is successful, we can move the closure to VM memory
@@ -160,7 +161,7 @@ result_void_position_t let(value_t *result, arena_t *temp_arena,
     frame_handle_t bindings_frame = arenaAllocationFrameStart(temp_arena);
     value_t evaluated;
     tryCatch(result_void_position_t,
-             evaluate(&evaluated, temp_arena, &body, local_env),
+             evaluate(&evaluated, temp_arena, temp_arena, &body, local_env),
              environmentDestroy(&local_env));
     tryCatch(result_void_position_t,
              addToEnvironment(symbol.value.symbol, &evaluated, local_env,
@@ -172,7 +173,7 @@ result_void_position_t let(value_t *result, arena_t *temp_arena,
   node_t form = listGet(node_t, nodes, 2);
   value_t temp_result;
   tryCatch(result_void_position_t,
-           evaluate(&temp_result, temp_arena, &form, local_env),
+           evaluate(&temp_result, temp_arena, temp_arena, &form, local_env),
            environmentDestroy(&local_env));
 
   // The result from the evaluation might be allocated in the local_env's arena,
@@ -202,7 +203,8 @@ result_void_position_t cond(value_t *result, arena_t *temp_arena,
     }
 
     node_t condition = listGet(node_t, &node.value.list, 0);
-    try(result_void_position_t, evaluate(result, temp_arena, &condition, env));
+    try(result_void_position_t,
+        evaluate(result, temp_arena, temp_arena, &condition, env));
 
     if (result->type != VALUE_TYPE_BOOLEAN) {
       arenaAllocationFrameEnd(temp_arena, frame);
@@ -212,13 +214,15 @@ result_void_position_t cond(value_t *result, arena_t *temp_arena,
 
     if (result->value.boolean) {
       node_t form = listGet(node_t, &node.value.list, 1);
-      try(result_void_position_t, evaluate(result, temp_arena, &form, env));
+      try(result_void_position_t,
+          evaluate(result, temp_arena, temp_arena, &form, env));
       return ok(result_void_position_t);
     }
     arenaAllocationFrameEnd(temp_arena, frame);
   }
 
   node_t fallback = listGet(node_t, nodes, nodes->count - 1);
-  try(result_void_position_t, evaluate(result, temp_arena, &fallback, env));
+  try(result_void_position_t,
+      evaluate(result, temp_arena, temp_arena, &fallback, env));
   return ok(result_void_position_t);
 }

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -30,7 +30,7 @@ static result_void_position_t addToEnvironment(const char *key, value_t *value,
 }
 
 const char *DEFINE_EXAMPLE = "(def! x (+ 1 2))";
-result_void_position_t define(value_t *result, arena_t *temp_arena,
+result_void_position_t define(value_t *result, arena_t *scratch_arena,
                               environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0); // def! is always there
   node_t first = listGet(node_t, nodes, 0);
@@ -45,19 +45,19 @@ result_void_position_t define(value_t *result, arena_t *temp_arena,
           "%s requires a symbol and a form. %s", DEFINE, DEFINE_EXAMPLE);
   }
 
-  frame_handle_t frame = arenaAllocationFrameStart(temp_arena);
+  frame_handle_t frame = arenaAllocationFrameStart(scratch_arena);
 
   // Perform reduction in the temporary memory
   value_t reduced;
   node_t value = listGet(node_t, nodes, 2);
   tryCatch(result_void_position_t,
-           evaluate(&reduced, temp_arena, temp_arena, &value, env),
-           arenaAllocationFrameEnd(temp_arena, frame));
+           evaluate(&reduced, scratch_arena, scratch_arena, &value, env),
+           arenaAllocationFrameEnd(scratch_arena, frame));
 
   // If reduction is successful, we can move the closure to VM memory
   tryFinally(result_void_position_t,
              addToEnvironment(key.value.symbol, &reduced, env, value.position),
-             arenaAllocationFrameEnd(temp_arena, frame));
+             arenaAllocationFrameEnd(scratch_arena, frame));
 
   result->type = VALUE_TYPE_NIL;
   result->value.nil = nullptr;
@@ -66,7 +66,7 @@ result_void_position_t define(value_t *result, arena_t *temp_arena,
 }
 
 const char *FUNCTION_EXAMPLE = "(fn (a b) (+ a b))";
-result_void_position_t function(value_t *result, arena_t *temp_arena,
+result_void_position_t function(value_t *result, arena_t *scratch_arena,
                                 environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0); // fn is always there
   node_t first = listGet(node_t, nodes, 0);
@@ -85,21 +85,21 @@ result_void_position_t function(value_t *result, arena_t *temp_arena,
 
   node_t form = listGet(node_t, nodes, 2);
 
-  frame_handle_t frame = arenaAllocationFrameStart(temp_arena);
-  tryWithMeta(result_void_position_t, valueInit(result, temp_arena, form.type),
-              result->position);
+  frame_handle_t frame = arenaAllocationFrameStart(scratch_arena);
+  tryWithMeta(result_void_position_t,
+              valueInit(result, scratch_arena, form.type), result->position);
 
   for (size_t i = 0; i < arguments.value.list.count; i++) {
     node_t argument = listGet(node_t, &arguments.value.list, i);
     if (argument.type != NODE_TYPE_SYMBOL) {
-      arenaAllocationFrameEnd(temp_arena, frame);
+      arenaAllocationFrameEnd(scratch_arena, frame);
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, argument.position,
             "%s requires a binding list of symbols. %s", FUNCTION,
             FUNCTION_EXAMPLE);
     }
 
     if (environmentResolveSymbol(env, argument.value.symbol)) {
-      arenaAllocationFrameEnd(temp_arena, frame);
+      arenaAllocationFrameEnd(scratch_arena, frame);
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, argument.position,
             "identifier '%s' shadows a value", argument.value.symbol);
     }
@@ -107,18 +107,18 @@ result_void_position_t function(value_t *result, arena_t *temp_arena,
     tryCatchWithMeta(
         result_void_position_t,
         listAppend(node_t, &result->value.closure.arguments, &argument),
-        arenaAllocationFrameEnd(temp_arena, frame), argument.position);
+        arenaAllocationFrameEnd(scratch_arena, frame), argument.position);
   }
 
   tryWithMeta(result_void_position_t,
-              nodeCopy(&form, &result->value.closure.form, temp_arena),
+              nodeCopy(&form, &result->value.closure.form, scratch_arena),
               form.position);
 
   return ok(result_void_position_t);
 }
 
 const char *LET_EXAMPLE = "(let ((a 1) (b 2)) (+ a b))";
-result_void_position_t let(value_t *result, arena_t *temp_arena,
+result_void_position_t let(value_t *result, arena_t *scratch_arena,
                            environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0); // let is always there
   node_t first = listGet(node_t, nodes, 0);
@@ -158,29 +158,31 @@ result_void_position_t let(value_t *result, arena_t *temp_arena,
     }
 
     node_t body = listGet(node_t, &couple.value.list, 1);
-    frame_handle_t bindings_frame = arenaAllocationFrameStart(temp_arena);
+    frame_handle_t bindings_frame = arenaAllocationFrameStart(scratch_arena);
     value_t evaluated;
-    tryCatch(result_void_position_t,
-             evaluate(&evaluated, temp_arena, temp_arena, &body, local_env),
-             environmentDestroy(&local_env));
+    tryCatch(
+        result_void_position_t,
+        evaluate(&evaluated, scratch_arena, scratch_arena, &body, local_env),
+        environmentDestroy(&local_env));
     tryCatch(result_void_position_t,
              addToEnvironment(symbol.value.symbol, &evaluated, local_env,
                               evaluated.position),
              environmentDestroy(&local_env));
-    arenaAllocationFrameEnd(temp_arena, bindings_frame);
+    arenaAllocationFrameEnd(scratch_arena, bindings_frame);
   }
 
   node_t form = listGet(node_t, nodes, 2);
   value_t temp_result;
-  tryCatch(result_void_position_t,
-           evaluate(&temp_result, temp_arena, temp_arena, &form, local_env),
-           environmentDestroy(&local_env));
+  tryCatch(
+      result_void_position_t,
+      evaluate(&temp_result, scratch_arena, scratch_arena, &form, local_env),
+      environmentDestroy(&local_env));
 
   // The result from the evaluation might be allocated in the local_env's arena,
   // which will be destroyed. We need to copy it to the temp arena to allow
   // expressions like `(let ((l (1 2))) l)` where values can escape the env
   tryWithMeta(result_void_position_t,
-              valueCopy(&temp_result, result, temp_arena),
+              valueCopy(&temp_result, result, scratch_arena),
               temp_result.position);
 
   environmentDestroy(&local_env);
@@ -188,15 +190,15 @@ result_void_position_t let(value_t *result, arena_t *temp_arena,
 }
 
 const char *COND_EXAMPLE = "\n  (cond\n    ((!= x 0) (/ 10 x))\n    (+ x 10))";
-result_void_position_t cond(value_t *result, arena_t *temp_arena,
+result_void_position_t cond(value_t *result, arena_t *scratch_arena,
                             environment_t *env, const node_list_t *nodes) {
   assert(nodes->count > 0);
 
   for (size_t i = 1; i < nodes->count - 1; i++) {
-    frame_handle_t frame = arenaAllocationFrameStart(temp_arena);
+    frame_handle_t frame = arenaAllocationFrameStart(scratch_arena);
     node_t node = listGet(node_t, nodes, i);
     if (node.type != NODE_TYPE_LIST || node.value.list.count != 2) {
-      arenaAllocationFrameEnd(temp_arena, frame);
+      arenaAllocationFrameEnd(scratch_arena, frame);
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, node.position,
             "%s requires a list of condition-form assignments. %s", COND,
             COND_EXAMPLE);
@@ -204,10 +206,10 @@ result_void_position_t cond(value_t *result, arena_t *temp_arena,
 
     node_t condition = listGet(node_t, &node.value.list, 0);
     try(result_void_position_t,
-        evaluate(result, temp_arena, temp_arena, &condition, env));
+        evaluate(result, scratch_arena, scratch_arena, &condition, env));
 
     if (result->type != VALUE_TYPE_BOOLEAN) {
-      arenaAllocationFrameEnd(temp_arena, frame);
+      arenaAllocationFrameEnd(scratch_arena, frame);
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, node.position,
             "Conditions should resolve to a boolean. %s", COND_EXAMPLE);
     }
@@ -215,14 +217,14 @@ result_void_position_t cond(value_t *result, arena_t *temp_arena,
     if (result->value.boolean) {
       node_t form = listGet(node_t, &node.value.list, 1);
       try(result_void_position_t,
-          evaluate(result, temp_arena, temp_arena, &form, env));
+          evaluate(result, scratch_arena, scratch_arena, &form, env));
       return ok(result_void_position_t);
     }
-    arenaAllocationFrameEnd(temp_arena, frame);
+    arenaAllocationFrameEnd(scratch_arena, frame);
   }
 
   node_t fallback = listGet(node_t, nodes, nodes->count - 1);
   try(result_void_position_t,
-      evaluate(result, temp_arena, temp_arena, &fallback, env));
+      evaluate(result, scratch_arena, scratch_arena, &fallback, env));
   return ok(result_void_position_t);
 }

--- a/lifp/specials.h
+++ b/lifp/specials.h
@@ -3,15 +3,15 @@
 #include "value.h"
 
 constexpr char DEFINE[] = "def!";
-result_void_position_t define(value_t *result, arena_t *temp_arena,
+result_void_position_t define(value_t *result, arena_t *scratch_arena,
                               environment_t *env, const node_list_t *nodes);
 
 constexpr char FUNCTION[] = "fn";
-result_void_position_t function(value_t *result, arena_t *temp_arena,
+result_void_position_t function(value_t *result, arena_t *scratch_arena,
                                 environment_t *env, const node_list_t *nodes);
 constexpr char LET[] = "let";
-result_void_position_t let(value_t *result, arena_t *temp_arena,
+result_void_position_t let(value_t *result, arena_t *scratch_arena,
                            environment_t *env, const node_list_t *nodes);
 constexpr char COND[] = "cond";
-result_void_position_t cond(value_t *result, arena_t *temp_arena,
+result_void_position_t cond(value_t *result, arena_t *scratch_arena,
                             environment_t *env, const node_list_t *nodes);

--- a/lifp/std/list.c
+++ b/lifp/std/list.c
@@ -29,12 +29,10 @@ result_void_position_t listCount(arena_t *arena, value_t *result,
 const char *LIST_FROM = "list.from";
 result_void_position_t listFrom(arena_t *arena, value_t *result,
                                 value_list_t *values) {
-  (void)arena;
   result->type = VALUE_TYPE_LIST;
 
   value_list_t *new_list = nullptr;
-  tryWithMeta(result_void_position_t,
-              listCreate(value_t, values->arena, values->count),
+  tryWithMeta(result_void_position_t, listCreate(value_t, arena, values->count),
               result->position, new_list);
   result->value.list = *new_list;
 
@@ -42,8 +40,11 @@ result_void_position_t listFrom(arena_t *arena, value_t *result,
     // Copy all values to the new list
     for (size_t i = 0; i < values->count; i++) {
       value_t source = listGet(value_t, values, i);
+      value_t duplicated;
       tryWithMeta(result_void_position_t,
-                  listAppend(value_t, &result->value.list, &source),
+                  valueCopy(&source, &duplicated, arena), result->position);
+      tryWithMeta(result_void_position_t,
+                  listAppend(value_t, &result->value.list, &duplicated),
                   source.position);
     }
   } else {

--- a/lifp/value.c
+++ b/lifp/value.c
@@ -27,8 +27,7 @@ result_void_t valueInitClosure(value_t *self, arena_t *arena,
                                node_type_t form_type) {
   self->type = VALUE_TYPE_CLOSURE;
   node_list_t *arguments = nullptr;
-  try(result_void_t, listCreate(node_t, arena, VALUE_LIST_INITIAL_SIZE),
-      arguments);
+  try(result_void_t, listCreate(node_t, arena, 2), arguments);
   self->value.closure.arguments = *arguments;
 
   node_t *form = nullptr;

--- a/lifp/value.h
+++ b/lifp/value.h
@@ -52,8 +52,6 @@ typedef struct value_t {
   } value;
 } value_t;
 
-constexpr size_t VALUE_LIST_INITIAL_SIZE = 8;
-
 result_void_t valueCopy(value_t *source, value_t *destination,
                         arena_t *destination_arena);
 result_ref_t valueCreate(arena_t *arena, value_type_t type);

--- a/lifp/virtual_machine.c
+++ b/lifp/virtual_machine.c
@@ -19,7 +19,7 @@
 static Map(value_t) * builtins;
 static Map(value_t) * specials;
 
-constexpr size_t ENVIRONMENT_MAX_SIZE = (long)32 * 1024;
+constexpr size_t ENVIRONMENT_MAX_SIZE = (long)64 * 1024;
 
 result_ref_t vmInit() {
   environment_t *global_environment = nullptr;

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -68,6 +68,18 @@ int main() {
   value_t second = listGet(value_t, &list.value.list, 1);
   expectEqlDouble(second.value.number, 2, "correct second item");
   
+  case("nested list");
+  value_t nested_list;
+  execute(&nested_list, "((1) 2)");
+  expectEqlUint(nested_list.type, VALUE_TYPE_LIST, "returns a list");
+  expectEqlUint(nested_list.value.list.data[0].type, VALUE_TYPE_LIST, "with nested list");
+
+  case("immediate invocation");
+  value_t immediate_invocation;
+  execute(&immediate_invocation, "((fn (a) a) 2)");
+  expectEqlUint(immediate_invocation.type, VALUE_TYPE_NUMBER, "returns a number");
+  expectEqlDouble(immediate_invocation.value.number, 2, "with correct value");
+
   case("simple form");
   value_t simple;
   execute(&simple, "(+ 1 2)");

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -102,6 +102,11 @@ int main() {
   expectEqlUint(fun.type, VALUE_TYPE_NUMBER, "returns correct type");
   expectEqlDouble(fun.value.number, 3, "returns correct value");
   
+  case("functions with non-inline types");
+  value_t fun2;
+  execute(&fun2, "(def! comma (fn (s) (str.join \", \" s)))\n(comma (\"1\" \"2\"))");
+  expectEqlUint(fun2.type, VALUE_TYPE_STRING, "returns correct type");
+
   case("let");
   value_t let;
   execute(&let, "(let ((plus (fn (x y) (+ x y))) (a 1)) (plus a 1))");

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -65,42 +65,42 @@ void transientAllocations(void) {
   size_t usage = getArenaMemoryUsage(test_result_arena);
 
   case("inlined values");
-  execute("3");
+  tryAssert(execute("3"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
   "not persisted for simple evaluations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(+ 1 2 3)");
+  tryAssert(execute("(+ 1 2 3)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
   "not persisted for builtins invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("((fn (a b) (+ a b)) 10 20)");
+  tryAssert(execute("((fn (a b) (+ a b)) 10 20)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
   "not persisted for closure invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(+ (+ 1 2) (+ 3 4))");
+  tryAssert(execute("(+ (+ 1 2) (+ 3 4))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
   "not persisted for nested invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
   case("allocated values");
-  execute("(1 2 3 4 5)");
+  tryAssert(execute("(1 2 3 4 5)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + (sizeof(value_t) * 5) +
                     sizeof(List(value_t)),
                 "persisted for simple evaluations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(list.from 1 2 3 4 5)");
+  tryAssert(execute("(list.from 1 2 3 4 5)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + (sizeof(value_t) * 5) +
                     sizeof(List(value_t)),
                 "persisted for builtin invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("((fn (a) (1 a)) 2)");
+  tryAssert(execute("((fn (a) (1 a)) 2)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + (sizeof(value_t) * 2) + sizeof(List(value_t)),
                 "persisted for closure invocations");
@@ -118,46 +118,46 @@ void letBindingsMemory(void) {
   size_t usage = getArenaMemoryUsage(test_result_arena);
 
   case("inlined values");
-  execute("(let ((x 10)) x)");
+  tryAssert(execute("(let ((x 10)) x)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted for simple evaluations");
   usage = getArenaMemoryUsage(test_result_arena);
   
-  execute("(let ((x 10) (y 20)) (+ x y))");
+  tryAssert(execute("(let ((x 10) (y 20)) (+ x y))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted for builtin invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(let ((x 1)) (let ((y 2)) (+ x y)))");
+  tryAssert(execute("(let ((x 1)) (let ((y 2)) (+ x y)))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted after nested let bindings");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(let ((f (fn (a) (+ a 1)))) (f 10))");
+  tryAssert(execute("(let ((f (fn (a) (+ a 1)))) (f 10))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted after let with closures");
   usage = getArenaMemoryUsage(test_result_arena);
   
   case("allocated values");
-  execute("(let ((x 10)) (x))");
+  tryAssert(execute("(let ((x 10)) (x))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), 
                 usage + sizeof(List(value_t)) + sizeof(value_t),
                 "persisted for simple evaluations");
   usage = getArenaMemoryUsage(test_result_arena);
   
-  execute("(let ((x 10) (y 20)) (list.from x y))");
+  tryAssert(execute("(let ((x 10) (y 20)) (list.from x y))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
                 "persisted for builtin invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(let ((x 1)) (let ((y 2)) (x y)))");
+  tryAssert(execute("(let ((x 1)) (let ((y 2)) (x y)))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
                 "persisted for nested let bindings");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(let ((f (fn (a) (+ a 1)))) (list.from (f 10)))");
+  tryAssert(execute("(let ((f (fn (a) (+ a 1)))) (list.from (f 10)))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t)),
                 "persisted for let with closures");
@@ -171,32 +171,32 @@ void conditionalMemory(void) {
   size_t usage = getArenaMemoryUsage(test_result_arena);
 
   case("inlined values");
-  execute("(cond ((= 1 1) 42) 0)");
+  tryAssert(execute("(cond ((= 1 1) 42) 0)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted for conditional");
 
-  execute("(cond ((= 1 2) (+ 1 2)) ((= 2 2) (+ 3 4)) (+ 5 6))");
+  tryAssert(execute("(cond ((= 1 2) (+ 1 2)) ((= 2 2) (+ 3 4)) (+ 5 6))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted for multiple conditions");
 
-  execute("(cond ((= 1 1) (let ((x 10)) x)) 0)");
+  tryAssert(execute("(cond ((= 1 1) (let ((x 10)) x)) 0)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted for conditional with let");
   
   case("allocated values");
-  execute("(cond ((= 1 1) (42)) 0)");
+  tryAssert(execute("(cond ((= 1 1) (42)) 0)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t)),
                 "persisted for conditional");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(cond ((= 1 2) (1 2)) ((= 2 2) (3 4)) (5 6))");
+  tryAssert(execute("(cond ((= 1 2) (1 2)) ((= 2 2) (3 4)) (5 6))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
                 "persisted for multiple conditions");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(cond ((= 1 1) (let ((x 10)) (x))) (0))");
+  tryAssert(execute("(cond ((= 1 1) (let ((x 10)) (x))) (0))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t)),
                 "persisted for conditional with let");
@@ -210,25 +210,25 @@ void closureMemory(void) {
   size_t usage = getArenaMemoryUsage(test_result_arena);
 
   case("inlined values");
-  execute("(def! multiply (fn (a b) (* a b)))");
+  tryAssert(execute("(def! multiply (fn (a b) (* a b)))"));
   size_t after_def_temp = getArenaMemoryUsage(test_result_arena);
 
-  execute("(multiply 5 6)");
+  tryAssert(execute("(multiply 5 6)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), after_def_temp,
                 "not persisted for closure invocation");
 
-  execute("(multiply 1 2)");
-  execute("(multiply 3 4)");
+  tryAssert(execute("(multiply 1 2)"));
+  tryAssert(execute("(multiply 3 4)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), after_def_temp,
                 "not persisted for multiple closure invocations");
 
-  execute("(def! complex (fn (x) (let ((y (+ x 1))) (cond ((= y 5) y) x))))");
-  execute("(complex 4)");
+  tryAssert(execute("(def! complex (fn (x) (let ((y (+ x 1))) (cond ((= y 5) y) x))))"));
+  tryAssert(execute("(complex 4)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "not persisted for complex closure");
 
   case("allocated values");
-  execute("(fn (a) a)");
+  tryAssert(execute("(fn (a) a)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage 
                   + sizeof(node_t) // form
@@ -238,21 +238,21 @@ void closureMemory(void) {
                 "persisted closure");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("((fn (a) a) (1 2))");
+  tryAssert(execute("((fn (a) a) (1 2))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage 
                 + sizeof(List(value_t)) + (sizeof(value_t) * 2),
                 "only persists returned value on immediate invocations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  execute(
-    "(def! complex2 (fn (x) (let ((y (+ x 1))) (cond ((= y 5) (y)) (x)))))");
+  tryAssert(execute(
+    "(def! complex2 (fn (x) (let ((y (+ x 1))) (cond ((= y 5) (y)) (x)))))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage,
                 "not persisted for definitions");
 
   usage = getArenaMemoryUsage(test_result_arena);
-  execute("(complex2 4)");
+  tryAssert(execute("(complex2 4)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage 
                 + sizeof(List(value_t)) + (sizeof(value_t)),
@@ -267,8 +267,8 @@ void recursiveMemory(void) {
   size_t usage = getArenaMemoryUsage(test_result_arena);
 
   case("inlined values");
-  execute("(def! count (fn (n) (cond ((= n 0) 0) (count (- n 1)))))");
-  execute("(count 20)");
+  tryAssert(execute("(def! count (fn (n) (cond ((= n 0) 0) (count (- n 1)))))"));
+  tryAssert(execute("(count 20)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "no persistence for recursion");
 
@@ -289,26 +289,26 @@ void errorHandlingMemory(void) {
   size_t usage = getArenaMemoryUsage(test_result_arena);
   size_t initial_safe_alloc = getTotalAllocatedBytes();
 
-  execute("(def! add2 (fn (a b) (+ a b)))");
-  execute("(add2 1)");
+  tryAssert(execute("(def! add2 (fn (a b) (+ a b)))"));
+  tryFail(execute("(add2 1)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after arity error");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from arity error");
 
-  execute("undefined");
+  tryFail(execute("undefined"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after undefined symbol error");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from undefined symbol error");
 
-  execute("((fn (1) a) 1)");
+  tryFail(execute("((fn (1) a) 1)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after invalid closure invocation");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from invalid closure");
 
-  execute("(let ((x undefined_var)) x)");
+  tryFail(execute("(let ((x undefined_var)) x)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after let binding error");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
@@ -320,13 +320,13 @@ void errorHandlingMemory(void) {
 }
 
 void danglingArenas(void) {
-  execute("((fn (a) a) 1 2)");
+  tryFail(execute("((fn (a) a) 1 2)"));
   expectEqlSize(getUsedArenas(), 4, "no dangling arena on failure");
 
-  execute("(def! rec (fn (a) (cond ((= a 0) 1) (rec (- a 1)))))\n(rec 10)");
+  tryAssert(execute("(def! rec (fn (a) (cond ((= a 0) 1) (rec (- a 1)))))\n(rec 10)"));
   expectEqlSize(getUsedArenas(), 4, "no dangling arena on recursive calls");
 
-  execute("(def! rec (fn (a) (cond ((= a 0) 1) (lol (- a 1)))))\n(rec 10)");
+  tryFail(execute("(def! rec (fn (a) (cond ((= a 0) 1) (lol (- a 1)))))\n(rec 10)"));
   expectEqlSize(getUsedArenas(), 4, "no dangling arena on nested errors");
 }
 

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -13,7 +13,7 @@
 allocMetricsInit();
 
 static arena_t *test_ast_arena;
-static arena_t *test_temp_arena;
+static arena_t *test_scratch_arena;
 static arena_t *test_result_arena;
 static environment_t *global;
 
@@ -27,7 +27,7 @@ void execute(const char *input) {
 
   while (line != NULL) {
     arenaReset(test_ast_arena);
-    arenaReset(test_temp_arena);
+    arenaReset(test_scratch_arena);
     token_list_t *tokens = nullptr;
     tryAssert(tokenize(test_ast_arena, line), tokens);
 
@@ -37,7 +37,7 @@ void execute(const char *input) {
     tryAssert(parse(test_ast_arena, tokens, &offset, &depth), ast);
 
     value_t result;
-    evaluate(&result, test_result_arena, test_temp_arena, ast, global);
+    evaluate(&result, test_result_arena, test_scratch_arena, ast, global);
 
     line = strtok(nullptr, "\n");
   }
@@ -318,7 +318,7 @@ void danglingArenas(void) {
 
 int main(void) {
   tryAssert(arenaCreate((size_t)(64 * 1024)), test_ast_arena);
-  tryAssert(arenaCreate((size_t)(32 * 1024)), test_temp_arena);
+  tryAssert(arenaCreate((size_t)(32 * 1024)), test_scratch_arena);
   tryAssert(arenaCreate((size_t)(32 * 1024)), test_result_arena);
   tryAssert(vmInit(), global);
 

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -206,8 +206,6 @@ int main(void) {
   suite(recursiveMemory);
   suite(errorHandlingMemory);
   suite(danglingArenas);
-
-  return report();
 }
 #else
 #include <stdio.h>

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -14,6 +14,7 @@ allocMetricsInit();
 
 static arena_t *test_ast_arena;
 static arena_t *test_temp_arena;
+static arena_t *test_result_arena;
 static environment_t *global;
 
 // This execute function does stack allocations, hence why we expect no
@@ -36,7 +37,7 @@ void execute(const char *input) {
     tryAssert(parse(test_ast_arena, tokens, &offset, &depth), ast);
 
     value_t result;
-    evaluate(&result, test_temp_arena, ast, global);
+    evaluate(&result, test_result_arena, test_temp_arena, ast, global);
 
     line = strtok(nullptr, "\n");
   }
@@ -56,126 +57,249 @@ size_t getTotalAllocatedBytes(void) { return allocGetMetrics().bytes; }
 size_t getArenaMemoryUsage(arena_t *arena) { return arena->offset; }
 
 void transientAllocations(void) {
-  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t usage = getArenaMemoryUsage(test_result_arena);
+
+  case("inlined values");
+  execute("3");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+  "not persisted for simple evaluations");
+  usage = getArenaMemoryUsage(test_result_arena);
 
   execute("(+ 1 2 3)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after simple invocation");
-
-  execute("(def! add (fn (a b) (+ a b)))");
-  execute("(add 10 20)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after closure invocation");
-
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+  "not persisted for builtins invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
+  execute("((fn (a b) (+ a b)) 10 20)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+  "not persisted for closure invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
   execute("(+ (+ 1 2) (+ 3 4))");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after nested evaluations");
-
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+  "not persisted for nested invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
+  case("allocated values");
   execute("(1 2 3 4 5)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after list evaluation");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + (sizeof(value_t) * 5) +
+                    sizeof(List(value_t)),
+                "persisted for simple evaluations");
+  usage = getArenaMemoryUsage(test_result_arena);
 
+  execute("(list.from 1 2 3 4 5)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + (sizeof(value_t) * 5) +
+                    sizeof(List(value_t)),
+                "persisted for builtin invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
+  execute("((fn (a) (1 a)) 2)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + (sizeof(value_t) * 2) +
+                sizeof(List(value_t)),
+                "persisted for closure invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  // TODO: there is no way of nesting builtins for non stack allocated values yet
+  
   arenaReset(test_ast_arena);
-  arenaReset(test_temp_arena);
+  arenaReset(test_result_arena);
 }
 
 void letBindingsMemory(void) {
-  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t usage = getArenaMemoryUsage(test_result_arena);
 
+  case("inlined values");
+  execute("(let ((x 10)) x)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted for simple evaluations");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
   execute("(let ((x 10) (y 20)) (+ x y))");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after let binding");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted for builtin invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
 
   execute("(let ((x 1)) (let ((y 2)) (+ x y)))");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after nested let bindings");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted after nested let bindings");
+  usage = getArenaMemoryUsage(test_result_arena);
 
   execute("(let ((f (fn (a) (+ a 1)))) (f 10))");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after let with closures");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted after let with closures");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
+  case("allocated values");
+  execute("(let ((x 10)) (x))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), 
+                usage + sizeof(List(value_t)) + sizeof(value_t),
+                "persisted for simple evaluations");
+  usage = getArenaMemoryUsage(test_result_arena);
+  
+  execute("(let ((x 10) (y 20)) (list.from x y))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
+                "persisted for builtin invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  execute("(let ((x 1)) (let ((y 2)) (x y)))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
+                "persisted for nested let bindings");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  execute("(let ((f (fn (a) (+ a 1)))) (list.from (f 10)))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + sizeof(List(value_t)) + (sizeof(value_t)),
+                "persisted for let with closures");
 
   arenaReset(test_ast_arena);
-  arenaReset(test_temp_arena);
+  arenaReset(test_result_arena);
 }
 
 void conditionalMemory(void) {
-  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t usage = getArenaMemoryUsage(test_result_arena);
 
+  case("inlined values");
   execute("(cond ((= 1 1) 42) 0)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after conditional");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted for conditional");
 
   execute("(cond ((= 1 2) (+ 1 2)) ((= 2 2) (+ 3 4)) (+ 5 6))");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after multiple conditions");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted for multiple conditions");
 
   execute("(cond ((= 1 1) (let ((x 10)) x)) 0)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after conditional with let");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted for conditional with let");
+  
+  case("allocated values");
+  execute("(cond ((= 1 1) (42)) 0)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + sizeof(List(value_t)) + (sizeof(value_t)),
+                "persisted for conditional");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  execute("(cond ((= 1 2) (1 2)) ((= 2 2) (3 4)) (5 6))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
+                "persisted for multiple conditions");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  execute("(cond ((= 1 1) (let ((x 10)) (x))) (0))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage + sizeof(List(value_t)) + (sizeof(value_t)),
+                "persisted for conditional with let");
 
   arenaReset(test_ast_arena);
-  arenaReset(test_temp_arena);
+  arenaReset(test_result_arena);
 }
 
 void closureMemory(void) {
-  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t usage = getArenaMemoryUsage(test_result_arena);
 
+  case("inlined values");
   execute("(def! multiply (fn (a b) (* a b)))");
-  size_t after_def_temp = getArenaMemoryUsage(test_temp_arena);
+  size_t after_def_temp = getArenaMemoryUsage(test_result_arena);
 
   execute("(multiply 5 6)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), after_def_temp,
-                "cleans arena after closure invocation");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), after_def_temp,
+                "not persisted for closure invocation");
 
   execute("(multiply 1 2)");
   execute("(multiply 3 4)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), after_def_temp,
-                "cleans arena after multiple closure invocations");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), after_def_temp,
+                "not persisted for multiple closure invocations");
 
   execute("(def! complex (fn (x) (let ((y (+ x 1))) (cond ((= y 5) y) x))))");
   execute("(complex 4)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after complex closure");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "not persisted for complex closure");
+
+  case("allocated values");
+  execute("(fn (a) a)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage 
+                  + sizeof(node_t) // form
+                  + (sizeof(char)*8) // form symbol
+                  + sizeof(List(node_t)) + (sizeof(node_t) * 2) // arguments 
+                  + (sizeof(char)*8), // argument symbol
+                "persisted closure");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  execute("((fn (a) a) (1 2))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage 
+                + sizeof(List(value_t)) + (sizeof(value_t) * 2),
+                "only persists returned value on immediate invocations");
+  usage = getArenaMemoryUsage(test_result_arena);
+
+  execute(
+    "(def! complex2 (fn (x) (let ((y (+ x 1))) (cond ((= y 5) (y)) (x)))))");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage,
+                "not persisted for definitions");
+
+  usage = getArenaMemoryUsage(test_result_arena);
+  execute("(complex2 4)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena),
+                usage 
+                + sizeof(List(value_t)) + (sizeof(value_t)),
+                "only persists returned value on persistent invocations");
+
+  arenaReset(test_ast_arena);
+  arenaReset(test_result_arena);
 }
 
 void recursiveMemory(void) {
-  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t usage = getArenaMemoryUsage(test_result_arena);
 
-  execute("(def! countdown (fn (n) (cond ((= n 0) 0) (countdown (- n 1)))))");
-  execute("(countdown 5)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after recursive calls");
+  case("inlined values");
+  execute("(def! count (fn (n) (cond ((= n 0) 0) (count (- n 1)))))");
+  execute("(count 20)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
+                "no persistence for recursion");
 
-  execute("(countdown 20)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
-                "cleans arena after deep recursion");
+  case("allocated values");
+  execute("(def! count2 (fn (n) (cond ((= n 0) (0)) (count2 (- n 1)))))");
+  execute("(count2 20)");
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), 
+                usage 
+                + sizeof(List(value_t)) + (sizeof(value_t)),
+                "only persists returned value");
+  
+  arenaReset(test_ast_arena);
+  arenaReset(test_result_arena);
 }
 
 void errorHandlingMemory(void) {
-  size_t initial_temp_usage = getArenaMemoryUsage(test_temp_arena);
+  size_t usage = getArenaMemoryUsage(test_result_arena);
   size_t initial_safe_alloc = getTotalAllocatedBytes();
 
   execute("(def! add2 (fn (a b) (+ a b)))");
   execute("(add2 1)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after arity error");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from arity error");
 
   execute("undefined");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after undefined symbol error");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from undefined symbol error");
 
   execute("((fn (1) a) 1)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after invalid closure invocation");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from invalid closure");
 
   execute("(let ((x undefined_var)) x)");
-  expectEqlSize(getArenaMemoryUsage(test_temp_arena), initial_temp_usage,
+  expectEqlSize(getArenaMemoryUsage(test_result_arena), usage,
                 "cleans arena after let binding error");
   expectEqlSize(getTotalAllocatedBytes(), initial_safe_alloc,
                 "no memory leaks from let binding error");
@@ -183,18 +307,19 @@ void errorHandlingMemory(void) {
 
 void danglingArenas(void) {
   execute("((fn (a) a) 1 2)");
-  expectEqlSize(getUsedArenas(), 3, "no dangling arena on failure");
+  expectEqlSize(getUsedArenas(), 4, "no dangling arena on failure");
 
   execute("(def! rec (fn (a) (cond ((= a 0) 1) (rec (- a 1)))))\n(rec 10)");
-  expectEqlSize(getUsedArenas(), 3, "no dangling arena on recursive calls");
+  expectEqlSize(getUsedArenas(), 4, "no dangling arena on recursive calls");
 
   execute("(def! rec (fn (a) (cond ((= a 0) 1) (lol (- a 1)))))\n(rec 10)");
-  expectEqlSize(getUsedArenas(), 3, "no dangling arena on nested errors");
+  expectEqlSize(getUsedArenas(), 4, "no dangling arena on nested errors");
 }
 
 int main(void) {
-  tryAssert(arenaCreate((size_t)(1024 * 1024)), test_ast_arena);
-  tryAssert(arenaCreate((size_t)(1024 * 1024)), test_temp_arena);
+  tryAssert(arenaCreate((size_t)(64 * 1024)), test_ast_arena);
+  tryAssert(arenaCreate((size_t)(32 * 1024)), test_temp_arena);
+  tryAssert(arenaCreate((size_t)(32 * 1024)), test_result_arena);
   tryAssert(vmInit(), global);
 
   profileInit();
@@ -206,6 +331,8 @@ int main(void) {
   suite(recursiveMemory);
   suite(errorHandlingMemory);
   suite(danglingArenas);
+
+  return report();
 }
 #else
 #include <stdio.h>

--- a/tests/specials.test.c
+++ b/tests/specials.test.c
@@ -19,7 +19,8 @@ result_void_t execute(value_t *result, const char *input) {
   size_t depth = 0;
   node_t *ast;
   tryAssert(parse(test_arena, tokens, &offset, &depth), ast);
-  tryWithMeta(result_void_t, evaluate(result, test_arena, ast, environment),
+  tryWithMeta(result_void_t,
+              evaluate(result, test_arena, test_arena, ast, environment),
               nullptr);
   return ok(result_void_t);
 }

--- a/tests/specials.test.c
+++ b/tests/specials.test.c
@@ -107,12 +107,10 @@ void fnSpecialForm() {
   expectIncludeString(exec.message, "shadows a value",
                       "prevents shadowing globals");
 
-  tryAssert(execute(&result, "(def! cond 1)"));
   tryFail(execute(&result, "(fn (cond) (+ cond 1))"), exec);
   expectIncludeString(exec.message, "shadows a value",
                       "prevents shadowing specials");
 
-  tryAssert(execute(&result, "(def! and 1)"));
   tryFail(execute(&result, "(fn (and) (+ and 1))"), exec);
   expectIncludeString(exec.message, "shadows a value",
                       "prevents shadowing builtins");

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -14,7 +14,7 @@
 #define _concat(x, y) _concat_detail(x, y)
 
 // Prevent unused value warnings when built in RELEASE mode
-#ifdef NODEBUG
+#ifndef NDEBUG
 #define tryAssert(Action, ...)                                                 \
   auto _concat(result, __LINE__) = (Action);                                   \
   assert(_concat(result, __LINE__).code == RESULT_OK);                         \
@@ -24,7 +24,7 @@
   __VA_OPT__(__VA_ARGS__ =)(Action) __VA_OPT__(.value);
 #endif
 
-#ifdef NODEBUG
+#ifndef NDEBUG
 #define tryFail(Action, ...)                                                   \
   auto _concat(result, __LINE__) = (Action);                                   \
   assert(_concat(result, __LINE__).code != RESULT_OK);                         \

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -5,6 +5,7 @@
 #include "../lifp/value.h"
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define arraySize(array) (sizeof(array) / sizeof((array)[0]))

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -3,7 +3,6 @@
 #include "../lib/string.h"
 #include "../lifp/token.h"
 #include "../lifp/value.h"
-#include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
@@ -13,25 +12,23 @@
 #define _concat_detail(x, y) x##y
 #define _concat(x, y) _concat_detail(x, y)
 
-// Prevent unused value warnings when built in RELEASE mode
-#ifndef NDEBUG
 #define tryAssert(Action, ...)                                                 \
   auto _concat(result, __LINE__) = (Action);                                   \
-  assert(_concat(result, __LINE__).code == RESULT_OK);                         \
+  if (_concat(result, __LINE__).code != RESULT_OK) {                           \
+    printf("Error: %s\n", _concat(result, __LINE__).message);                  \
+    printf("    at: %s:%d\n", __FILE__, __LINE__);                             \
+    abort();                                                                   \
+  }                                                                            \
   __VA_OPT__(__VA_ARGS__ = _concat(result, __LINE__).value);
-#else
-#define tryAssert(Action, ...)                                                 \
-  __VA_OPT__(__VA_ARGS__ =)(Action) __VA_OPT__(.value);
-#endif
 
-#ifndef NDEBUG
 #define tryFail(Action, ...)                                                   \
   auto _concat(result, __LINE__) = (Action);                                   \
-  assert(_concat(result, __LINE__).code != RESULT_OK);                         \
+  if (_concat(result, __LINE__).code == RESULT_OK) {                           \
+    printf("Error: did not fail\n");                                           \
+    printf("    at: %s:%d\n", __FILE__, __LINE__);                             \
+    abort();                                                                   \
+  }                                                                            \
   __VA_OPT__(__VA_ARGS__ = _concat(result, __LINE__))
-#else
-#define tryFail(Action, ...) __VA_OPT__(__VA_ARGS__ =)(Action);
-#endif
 
 static inline token_list_t *
 makeTokenList(arena_t *arena, const token_t *elements, size_t capacity) {


### PR DESCRIPTION
## Lifecycle 
This change explicitly differentiates the lifecycle of return values and scratch values by splitting the temporary memory in two halves.

This stays consistent with the arena approach we used this far.

## Tests
En passant, this change adds also a bunch of new memory tests and integration tests.

## Scratch Memory Optimizations
This change also drops scratch memory optimizations. They allowed much deeper recursion, but they made the runtime very unpredictable, since the two lifecycles (arenas and frames) ended up intertwining.

We are dropping any further scratch memory optimization for now.