### PR TITLE
feat!: add last methods in std library for feature parity with previous implementation

### DIFF
--- a/.todo
+++ b/.todo
@@ -4,19 +4,17 @@ BUGS
 
 FEATURES
 ---
-  * [ ] Compile AST to bytecode
-  * [ ] Implement methods (list.times, io.printf!)
+  * [ ] Enum to text for error messages
+  * [ ] Auto-generated documentation for standard library
+  * [ ] Implement `?` in REPL
+  * [ ] imports `(import! my-module "./my-module.lifp")
   * [ ] Decouple validation from execution
   * [ ] Enforce naming conventions for functions
     * [ ] effectful functions should terminate with !
     * [ ] functions ending in ? should return bool
-  * [ ] Resizable arena, to allow resizable environments
-  * [ ] Tail call optimization
-  * [ ] Auto-generated documentation for standard library
-  * [ ] Enum to text for error messages
-  * [ ] Implement `?` in REPL
-  * [ ] imports `(import! my-module "./my-module.lifp")
   * [ ] Type Declaration comments `;; (number, number) -> number`
+  * [ ] Compile AST to bytecode
+  * [ ] Tail call optimization
 
 REFACTORING
 ---

--- a/cmd/repl.c
+++ b/cmd/repl.c
@@ -21,7 +21,7 @@ typedef struct {
 } repl_opts_t;
 
 static constexpr char REPL_COMMAND_CLEAR[] = "clear";
-void clean(void) { printf("\e[1;1H\e[2J"); }
+void clean(void) { puts("\e[1;1H\e[2J"); }
 static constexpr char REPL_COMMAND_HELP[] = "help";
 void help(void) {
   printf("lifp is a LISP dialect. Its syntax is made of expressions enclosed "

--- a/cmd/run.c
+++ b/cmd/run.c
@@ -1,4 +1,5 @@
 #include "../lifp/evaluate.h"
+#include "../lifp/fmt.h"
 #include "../lifp/parse.h"
 #include "../lifp/tokenize.h"
 #include "../lifp/virtual_machine.h"
@@ -24,10 +25,18 @@ typedef struct {
   const char *filename;
 } run_opts_t;
 
+#define printError(Result, InputBuffer, Size, OutputBuffer)                    \
+  int _concat(offset_, __LINE__) = 0;                                          \
+  formatErrorMessage((Result)->message, (Result)->meta, OPTIONS.filename,      \
+                     InputBuffer, Size, OutputBuffer,                          \
+                     &_concat(offset_, __LINE__));                             \
+  fprintf(stdout, "%s\n", OutputBuffer);
+
 #define tryRun(Action, ...)                                                    \
   auto _concat(result, __LINE__) = Action;                                     \
   if (_concat(result, __LINE__).code != RESULT_OK) {                           \
-    error("%s", _concat(result, __LINE__).message);                            \
+    char buffer[4096] = {0};                                                   \
+    printError(&_concat(result, __LINE__), statement_buffer, 4096, buffer);    \
     profileReport();                                                           \
     return 1;                                                                  \
   }                                                                            \

--- a/examples/conway.lifp
+++ b/examples/conway.lifp
@@ -1,0 +1,88 @@
+(def! BOARD_WIDTH 10)
+(def! BOARD_HEIGHT 10)
+(def! BOARD_SIZE (* BOARD_WIDTH BOARD_HEIGHT))
+(def! ALIVE "@")
+(def! DEAD " ")
+
+(def! if (fn (a b c) (cond (a b) c)))
+
+(def! init-board
+  ; Initializes the board
+  (fn ()
+    (list:map 
+      (fn (a i) (if (> (math:random!) 0.5) 1 0))
+      (list:times (fn (i) nil) BOARD_SIZE))))
+
+(def! alive?
+  ; Returns true if the current cell is alive
+  (fn (x) (= 1 x)))
+
+(def! pos?
+  ; Returns true if the input is positive
+  (fn (x) (> x 0)))
+
+(def! print-cell
+  ; Prints ALIVE for alive cell, and DEAD for a dead cell
+  (fn (cell idx)
+    (io:printf! "{} {}"
+      ((if (alive? cell) ALIVE DEAD)
+      (if (= (% (+ idx 1) BOARD_WIDTH) 0) "\n" "")))))
+
+(def! print-board
+  ; Prints the board
+  (fn (board)
+    (list:each print-cell board)))
+
+(def! up?    (fn (idx) (>= idx BOARD_WIDTH)))
+(def! down?  (fn (idx) (< idx (* BOARD_WIDTH (- BOARD_HEIGHT 1)))))
+(def! left?  (fn (idx) (<> (% idx BOARD_WIDTH) 0)))
+(def! right? (fn (idx) (<> (% idx BOARD_WIDTH) (- BOARD_WIDTH 1))))
+
+(def! get-neighbors
+  ; Returns neighbors index of a cell at a given row-major index
+  (fn (index)
+    (let ((candidates (list:from
+      (if (and (up? index) (left? index)) (- index BOARD_WIDTH 1) -1)
+      (if (up? index) (- index BOARD_WIDTH) -1)
+      (if (and (up? index) (right? index)) (- index BOARD_WIDTH -1) -1)
+      (if (left? index) (- index 1) -1)
+      (if (right? index) (+ index 1) -1)
+      (if (and (down? index) (left? index)) (+ index BOARD_WIDTH -1) -1)
+      (if (down? index) (+ index BOARD_WIDTH) -1)
+      (if (and (down? index) (right? index)) (+ index BOARD_WIDTH 1) -1)
+    )))
+    (list:filter pos? candidates))))
+
+(def! count-alive-neighbors
+  ; Returns the count of alive neighbors at a given index
+  (fn (board index)
+    (let ((is-alive? (fn (x) (= 1 (list:nth x board)))))
+      (list:count
+        (list:filter is-alive?
+          (get-neighbors index))))))
+
+(def! process-cell
+  ; Determines if a cell is a dead or alive given its surroundings
+  (fn (value index board)
+    (let ((alive-ns (count-alive-neighbors board index)))
+      (if (alive? value)
+        (if (or (= 2 alive-ns) (= 3 alive-ns)) 1 0)
+        (if (= 3 alive-ns) 1 0)))))
+
+(def! process-board
+  ; Determines the status of the board one cell at a time
+  (fn (board)
+    (list:map
+      (fn (cell idx) (process-cell cell idx board))
+      board)))
+
+(def! game-loop
+  (fn (board)
+    (let ((a (io:clear!))
+          (b (print-board board))
+          (c (io:readline! "Press [ENTER] to continue")))
+      (game-loop (process-board board)))))
+
+; Main
+(def! board (init-board))
+(game-loop board)

--- a/examples/conway.lifp
+++ b/examples/conway.lifp
@@ -24,8 +24,8 @@
 (def! print-cell
   ; Prints ALIVE for alive cell, and DEAD for a dead cell
   (fn (cell idx)
-    (io:printf! "{} {}"
-      ((if (alive? cell) ALIVE DEAD)
+    (io:printf! "{} {}" (
+      (if (alive? cell) ALIVE DEAD)
       (if (= (% (+ idx 1) BOARD_WIDTH) 0) "\n" "")))))
 
 (def! print-board

--- a/examples/fact.lifp
+++ b/examples/fact.lifp
@@ -2,6 +2,6 @@
 ; The syntax is very similar to other LISPs you may be familiar with
 (def! fact (fn (n) (cond ((< n 1) 1) (* n (fact (- n 1))))))
 
-(io.print! (fact 50))
+(io:print! (fact 50))
 
 ; vim:ft=lisp

--- a/examples/fibonacci.lifp
+++ b/examples/fibonacci.lifp
@@ -9,6 +9,6 @@
       ((= a 2) 2)
       (+ (fibonacci (- a 1)) (fibonacci (- a 2))))))
 
-(io.print! (fibonacci 8))
+(io:print! (fibonacci 8))
 
 ; vim:ft=lisp

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -15,9 +15,9 @@
 result_void_position_t invokeClosure(value_t *result, closure_t closure,
                                      value_list_t *arguments,
                                      arena_t *scratch_arena) {
-  if (arguments->count > closure.arguments.count) {
+  if (arguments->count < closure.arguments.count) {
     throw(result_void_position_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
-          result->position,
+          closure.form.position,
           "Unexpected arity. Expected %lu arguments, got %lu.",
           closure.arguments.count, arguments->count);
   }
@@ -28,7 +28,7 @@ result_void_position_t invokeClosure(value_t *result, closure_t closure,
               result->position, local_environment);
 
   // Populate the closure with the values, skipping the closure
-  for (size_t i = 0; i < arguments->count; i++) {
+  for (size_t i = 0; i < closure.arguments.count; i++) {
     auto argument = listGet(node_t, &closure.arguments, i);
     auto value = listGet(value_t, arguments, i);
     tryWithMeta(result_void_position_t,

--- a/lifp/evaluate.c
+++ b/lifp/evaluate.c
@@ -15,7 +15,7 @@
 result_void_position_t invokeClosure(value_t *result, closure_t closure,
                                      value_list_t *arguments,
                                      arena_t *scratch_arena) {
-  if (arguments->count != closure.arguments.count) {
+  if (arguments->count > closure.arguments.count) {
     throw(result_void_position_t, ERROR_CODE_TYPE_UNEXPECTED_ARITY,
           result->position,
           "Unexpected arity. Expected %lu arguments, got %lu.",

--- a/lifp/specials.c
+++ b/lifp/specials.c
@@ -4,6 +4,7 @@
 #include "error.h"
 #include "evaluate.h"
 #include "node.h"
+#include "token.h"
 #include "value.h"
 #include "virtual_machine.h"
 #include <assert.h>
@@ -45,6 +46,13 @@ result_void_position_t define(value_t *result, const node_list_t *nodes,
   if (key.type != NODE_TYPE_SYMBOL) {
     throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, first.position,
           "%s requires a symbol and a form. %s", DEFINE, DEFINE_EXAMPLE);
+  }
+
+  if (strchr(key.value.symbol, NAMESPACE_DELIMITER) != NULL) {
+    throw(result_void_position_t, ERROR_CODE_SYNTAX_UNEXPECTED_TOKEN,
+          first.position,
+          "Unexpected namespace delimiter '%c' in custom symbol '%s'.",
+          NAMESPACE_DELIMITER, key.value.symbol);
   }
 
   // Perform reduction in the temporary memory
@@ -161,6 +169,13 @@ result_void_position_t let(value_t *result, const node_list_t *nodes,
       throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, symbol.position,
             "%s requires a list of symbol-form assignments. %s", LET,
             LET_EXAMPLE);
+    }
+
+    if (strchr(symbol.value.symbol, NAMESPACE_DELIMITER) != NULL) {
+      throw(result_void_position_t, ERROR_CODE_SYNTAX_UNEXPECTED_TOKEN,
+            first.position,
+            "Unexpected namespace delimiter '%c' in custom symbol '%s'.",
+            NAMESPACE_DELIMITER, symbol.value.symbol);
     }
 
     node_t body = listGet(node_t, &couple.value.list, 1);

--- a/lifp/std/flow.c
+++ b/lifp/std/flow.c
@@ -8,7 +8,7 @@
 #include <time.h>
 #include <unistd.h>
 
-const char *FLOW_SLEEP = "flow.sleep";
+const char *FLOW_SLEEP = "flow:sleep";
 
 result_void_position_t flowSleep(value_t *result, const value_list_t *arguments,
                                  arena_t *arena) {

--- a/lifp/std/io.c
+++ b/lifp/std/io.c
@@ -141,7 +141,7 @@ result_void_position_t ioReadline(value_t *result, const value_list_t *values,
   char buffer[INTERMEDIATE_BUFFER_SIZE];
   if (fgets(buffer, sizeof(buffer), stdin) == nullptr) {
     result->type = VALUE_TYPE_STRING;
-    result->value.string = nullptr;
+    *result->value.string = 0;
     return ok(result_void_position_t);
   }
 

--- a/lifp/std/io.c
+++ b/lifp/std/io.c
@@ -1,24 +1,175 @@
 #include "../../lib/result.h"
+#include "../../lib/string.h"
 #include "../error.h"
 #include "../fmt.h"
 #include "../value.h"
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 
-const char *IO_PRINT = "io:print!";
-result_void_position_t ioPrint(value_t *result, const value_list_t *values,
-                               arena_t *arena) {
+constexpr size_t INTERMEDIATE_BUFFER_SIZE = 1024;
+
+static void streamPrint(FILE *stream, value_t *value) {
+  char buffer[INTERMEDIATE_BUFFER_SIZE];
+  int offset = 0;
+  formatValue(value, INTERMEDIATE_BUFFER_SIZE, buffer, &offset);
+  fprintf(stream, "%s\n", buffer);
+}
+
+const char *IO_STDOUT = "io:stdout!";
+result_void_position_t ioStdout(value_t *result, const value_list_t *values,
+                                arena_t *arena) {
   (void)arena;
   if (values->count != 1) {
     throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
-          "%s requires 1 argument. Got %zu", IO_PRINT, values->count);
+          "%s requires an argument. Got %zu", IO_STDOUT, values->count);
+  }
+
+  value_t value = listGet(value_t, values, 0);
+  streamPrint(stdout, &value);
+
+  result->type = VALUE_TYPE_NIL;
+  result->value.nil = nullptr;
+
+  return ok(result_void_position_t);
+}
+
+const char *IO_STDERR = "io:stderr!";
+result_void_position_t ioStderr(value_t *result, const value_list_t *values,
+                                arena_t *arena) {
+  (void)arena;
+  if (values->count != 1) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
+          "%s requires an argument. Got %zu", IO_STDERR, values->count);
   }
 
   value_t value = listGet(value_t, values, 0);
 
-  constexpr static size_t BUFFER_SIZE = 1024;
-  char buffer[BUFFER_SIZE];
-  int offset = 0;
-  formatValue(&value, BUFFER_SIZE, buffer, &offset);
-  printf("%s\n", buffer);
+  streamPrint(stderr, &value);
+
+  result->type = VALUE_TYPE_NIL;
+  result->value.nil = nullptr;
+
+  return ok(result_void_position_t);
+}
+
+const char *IO_PRINTF = "io:printf!";
+result_void_position_t ioPrintf(value_t *result, const value_list_t *values,
+                                arena_t *arena) {
+  (void)arena;
+  if (values->count != 2) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
+          "%s requires two arguments. Got %zu", IO_PRINTF, values->count);
+  }
+
+  value_t format_value = listGet(value_t, values, 0);
+  value_t inputs_value = listGet(value_t, values, 1);
+
+  if (format_value.type != VALUE_TYPE_STRING ||
+      inputs_value.type != VALUE_TYPE_LIST) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
+          "%s requires a format string and a list of arguments. "
+          "Got types %u and %u.",
+          IO_PRINTF, format_value.type, inputs_value.type);
+  }
+
+  value_list_t inputs = inputs_value.value.list;
+  char *format = format_value.value.string;
+
+  size_t placeholder_count = 0;
+  const char *placeholder = format;
+  while ((placeholder = strstr(placeholder, "{}")) != nullptr) {
+    placeholder++;
+    placeholder_count++;
+  }
+
+  if (placeholder_count > inputs.count) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR,
+          format_value.position,
+          "Cannot have more placholders than values. "
+          "Got %lu placeholders and %lu values.",
+          placeholder_count, inputs.count);
+  }
+
+  size_t index = 0;
+  const char *current = format;
+  while (*current) {
+    if (*current == '{' && *(current + 1) == '}') {
+      value_t value = listGet(value_t, &inputs, index);
+      if (value.type != VALUE_TYPE_STRING) {
+        char buffer[INTERMEDIATE_BUFFER_SIZE];
+        int offset = 0;
+        formatValue(&value, INTERMEDIATE_BUFFER_SIZE, buffer, &offset);
+        fputs(buffer, stdout);
+      } else {
+        // This prevents printing quotes in the formatted string
+        fputs(value.value.string, stdout);
+      }
+      index++;
+      current += 2;
+      continue;
+    }
+    putchar(*current);
+    current++;
+  }
+
+  result->type = VALUE_TYPE_NIL;
+  result->value.nil = nullptr;
+
+  return ok(result_void_position_t);
+}
+
+const char *IO_READLINE = "io:readline!";
+result_void_position_t ioReadline(value_t *result, const value_list_t *values,
+                                  arena_t *arena) {
+  if (values->count != 1) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
+          "%s requires an argument. Got %zu", IO_READLINE, values->count);
+  }
+
+  value_t question_value = listGet(value_t, values, 0);
+
+  if (question_value.type != VALUE_TYPE_STRING) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
+          "%s requires a string as a question. Got %u", IO_READLINE,
+          question_value.type);
+  }
+
+  printf("%s", question_value.value.string);
+
+  char buffer[INTERMEDIATE_BUFFER_SIZE];
+  if (fgets(buffer, sizeof(buffer), stdin) == nullptr) {
+    result->type = VALUE_TYPE_STRING;
+    result->value.string = nullptr;
+    return ok(result_void_position_t);
+  }
+
+  // Remove trailing newline if present
+  size_t len = strlen(buffer);
+  if (len > 0 && buffer[len - 1] == '\n') {
+    buffer[len - 1] = '\0';
+  }
+
+  result->type = VALUE_TYPE_STRING;
+  tryWithMeta(result_void_position_t, arenaAllocate(arena, len),
+              question_value.position, result->value.string);
+
+  stringCopy(result->value.string, buffer, len);
+
+  return ok(result_void_position_t);
+}
+
+const char *IO_CLEAR = "io:clear!";
+result_void_position_t ioClear(value_t *result, const value_list_t *values,
+                               arena_t *arena) {
+  (void)arena;
+  if (values->count != 0) {
+    throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
+          "%s takes no arguments. Got %zu", IO_READLINE, values->count);
+  }
+
+  puts("\e[1;1H\e[2J");
 
   result->type = VALUE_TYPE_NIL;
   result->value.nil = nullptr;

--- a/lifp/std/io.c
+++ b/lifp/std/io.c
@@ -3,7 +3,7 @@
 #include "../fmt.h"
 #include "../value.h"
 
-const char *IO_PRINT = "io.print!";
+const char *IO_PRINT = "io:print!";
 result_void_position_t ioPrint(value_t *result, const value_list_t *values,
                                arena_t *arena) {
   (void)arena;

--- a/lifp/std/io.c
+++ b/lifp/std/io.c
@@ -87,7 +87,7 @@ result_void_position_t ioPrintf(value_t *result, const value_list_t *values,
   if (placeholder_count > inputs.count) {
     throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR,
           format_value.position,
-          "Cannot have more placholders than values. "
+          "Cannot have more placeholders than values. "
           "Got %lu placeholders and %lu values.",
           placeholder_count, inputs.count);
   }
@@ -166,7 +166,7 @@ result_void_position_t ioClear(value_t *result, const value_list_t *values,
   (void)arena;
   if (values->count != 0) {
     throw(result_void_position_t, ERROR_CODE_RUNTIME_ERROR, result->position,
-          "%s takes no arguments. Got %zu", IO_READLINE, values->count);
+          "%s takes no arguments. Got %zu", IO_CLEAR, values->count);
   }
 
   puts("\e[1;1H\e[2J");

--- a/lifp/std/list.c
+++ b/lifp/std/list.c
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 // List count function - counts elements in a list
-const char *LIST_COUNT = "list.count";
+const char *LIST_COUNT = "list:count";
 result_void_position_t listCount(value_t *result, const value_list_t *arguments,
                                  arena_t *arena) {
   (void)arena;
@@ -28,7 +28,7 @@ result_void_position_t listCount(value_t *result, const value_list_t *arguments,
 }
 
 // List from function - creates a list from the given arguments
-const char *LIST_FROM = "list.from";
+const char *LIST_FROM = "list:from";
 result_void_position_t listFrom(value_t *result, const value_list_t *arguments,
                                 arena_t *arena) {
   result->type = VALUE_TYPE_LIST;
@@ -59,7 +59,7 @@ result_void_position_t listFrom(value_t *result, const value_list_t *arguments,
 
 // List nth function - returns the nth element of a list, or nil if out of
 // bounds
-const char *LIST_NTH = "list.nth";
+const char *LIST_NTH = "list:nth";
 result_void_position_t listNth(value_t *result, const value_list_t *arguments,
                                arena_t *arena) {
   (void)arena;
@@ -98,7 +98,7 @@ result_void_position_t listNth(value_t *result, const value_list_t *arguments,
   return ok(result_void_position_t);
 }
 
-const char *LIST_MAP = "list.map";
+const char *LIST_MAP = "list:map";
 result_void_position_t listMap(value_t *result, const value_list_t *arguments,
                                arena_t *arena) {
   if (arguments->count != 2) {
@@ -161,7 +161,7 @@ result_void_position_t listMap(value_t *result, const value_list_t *arguments,
   return ok(result_void_position_t);
 }
 
-const char *LIST_EACH = "list.each";
+const char *LIST_EACH = "list:each";
 result_void_position_t listEach(value_t *result, const value_list_t *arguments,
                                 arena_t *arena) {
   if (arguments->count != 2) {
@@ -216,7 +216,7 @@ result_void_position_t listEach(value_t *result, const value_list_t *arguments,
   return ok(result_void_position_t);
 }
 
-const char *LIST_FILTER = "list.filter";
+const char *LIST_FILTER = "list:filter";
 result_void_position_t
 listFilter(value_t *result, const value_list_t *arguments, arena_t *arena) {
   if (arguments->count != 2) {
@@ -289,7 +289,7 @@ listFilter(value_t *result, const value_list_t *arguments, arena_t *arena) {
   return ok(result_void_position_t);
 }
 
-const char *LIST_TIMES = "list.times";
+const char *LIST_TIMES = "list:times";
 result_void_position_t listTimes(value_t *result, const value_list_t *arguments,
                                  arena_t *arena) {
   if (arguments->count != 2) {

--- a/lifp/std/math.c
+++ b/lifp/std/math.c
@@ -7,7 +7,7 @@
 #include <time.h>
 
 // Math max function - returns the maximum value in a list of numbers
-const char *MATH_MAX = "math.max";
+const char *MATH_MAX = "math:max";
 result_void_position_t mathMax(value_t *result, const value_list_t *values,
                                arena_t *arena) {
   (void)arena;
@@ -50,7 +50,7 @@ result_void_position_t mathMax(value_t *result, const value_list_t *values,
 }
 
 // Math min function - returns the minimum value in a list of numbers
-const char *MATH_MIN = "math.min";
+const char *MATH_MIN = "math:min";
 result_void_position_t mathMin(value_t *result, const value_list_t *values,
                                arena_t *arena) {
   (void)arena;
@@ -93,7 +93,7 @@ result_void_position_t mathMin(value_t *result, const value_list_t *values,
 }
 
 // Math random function - returns a random number between 0 and RAND_MAX
-const char *MATH_RANDOM = "math.random!";
+const char *MATH_RANDOM = "math:random!";
 result_void_position_t mathRandom(value_t *result, const value_list_t *values,
                                   arena_t *arena) {
   (void)arena;
@@ -115,7 +115,7 @@ result_void_position_t mathRandom(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *MATH_CEIL = "math.ceil";
+const char *MATH_CEIL = "math:ceil";
 result_void_position_t mathCeil(value_t *result, const value_list_t *values,
                                 arena_t *arena) {
   (void)arena;
@@ -136,7 +136,7 @@ result_void_position_t mathCeil(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *MATH_FLOOR = "math.floor";
+const char *MATH_FLOOR = "math:floor";
 result_void_position_t mathFloor(value_t *result, const value_list_t *values,
                                  arena_t *arena) {
   (void)arena;

--- a/lifp/std/math.c
+++ b/lifp/std/math.c
@@ -92,7 +92,7 @@ result_void_position_t mathMin(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-// Math random function - returns a random number between 0 and RAND_MAX
+// Math random function - returns a random number between 0 and 1
 const char *MATH_RANDOM = "math:random!";
 result_void_position_t mathRandom(value_t *result, const value_list_t *values,
                                   arena_t *arena) {
@@ -110,7 +110,7 @@ result_void_position_t mathRandom(value_t *result, const value_list_t *values,
   }
 
   result->type = VALUE_TYPE_NUMBER;
-  result->value.number = rand();
+  result->value.number = (number_t)rand() / RAND_MAX;
 
   return ok(result_void_position_t);
 }

--- a/lifp/std/str.c
+++ b/lifp/std/str.c
@@ -12,7 +12,7 @@
               Buffer);                                                         \
   memset(Buffer, 0, Length);
 
-const char *STR_LENGTH = "str.length";
+const char *STR_LENGTH = "str:length";
 result_void_position_t strLength(value_t *result, const value_list_t *values,
                                  arena_t *arena) {
   (void)arena;
@@ -34,7 +34,7 @@ result_void_position_t strLength(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *STR_JOIN = "str.join";
+const char *STR_JOIN = "str:join";
 result_void_position_t strJoin(value_t *result, const value_list_t *values,
                                arena_t *arena) {
   if (values->count != 2) {
@@ -98,7 +98,7 @@ result_void_position_t strJoin(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *STR_SLICE = "str.slice";
+const char *STR_SLICE = "str:slice";
 result_void_position_t strSlice(value_t *result, const value_list_t *values,
                                 arena_t *arena) {
   if (values->count < 2 || values->count > 3) {
@@ -161,7 +161,7 @@ result_void_position_t strSlice(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *STR_INCLUDE = "str.include";
+const char *STR_INCLUDE = "str:include";
 result_void_position_t strInclude(value_t *result, const value_list_t *values,
                                   arena_t *arena) {
   (void)arena;
@@ -197,7 +197,7 @@ result_void_position_t strInclude(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *STR_TRIM_LEFT = "str.trimLeft";
+const char *STR_TRIM_LEFT = "str:trimLeft";
 result_void_position_t strTrimLeft(value_t *result, const value_list_t *values,
                                    arena_t *arena) {
   (void)arena;
@@ -231,7 +231,7 @@ result_void_position_t strTrimLeft(value_t *result, const value_list_t *values,
   return ok(result_void_position_t);
 }
 
-const char *STR_TRIM_RIGHT = "str.trimRight";
+const char *STR_TRIM_RIGHT = "str:trimRight";
 result_void_position_t strTrimRight(value_t *result, const value_list_t *values,
                                     arena_t *arena) {
   (void)arena;

--- a/lifp/token.h
+++ b/lifp/token.h
@@ -9,6 +9,7 @@ constexpr char LPAREN = '(';
 constexpr char RPAREN = ')';
 constexpr char STRING_DELIMITER = '"';
 constexpr char COMMENT_DELIMITER = ';';
+constexpr char NAMESPACE_DELIMITER = ':';
 constexpr char BOOLEAN_DELIMITER = '?';
 constexpr char EFFECTFUL_DEIMITER = '!';
 

--- a/lifp/tokenize.c
+++ b/lifp/tokenize.c
@@ -217,7 +217,7 @@ result_token_list_ref_t tokenize(arena_t *arena, const char *source) {
 
       if (!isValidSymbolName(str->count - 1, str->data)) {
         throw(result_token_list_ref_t, ERROR_CODE_SYNTAX_UNEXPECTED_TOKEN,
-              token_pos, "Invalid symbol name");
+              token_pos, "Invalid symbol name: '%s'", str->data);
       }
 
       char *remainder;

--- a/lifp/virtual_machine.c
+++ b/lifp/virtual_machine.c
@@ -73,7 +73,11 @@ result_vm_ref_t vmCreate(vm_options_t opts) {
   setBuiltin(STR_INCLUDE, strInclude);
   setBuiltin(STR_TRIM_LEFT, strTrimLeft);
   setBuiltin(STR_TRIM_RIGHT, strTrimRight);
-  setBuiltin(IO_PRINT, ioPrint);
+  setBuiltin(IO_STDOUT, ioStdout);
+  setBuiltin(IO_STDERR, ioStderr);
+  setBuiltin(IO_PRINTF, ioPrintf);
+  setBuiltin(IO_READLINE, ioReadline);
+  setBuiltin(IO_CLEAR, ioClear);
 #undef setBuiltin
 
   try(result_vm_ref_t, mapCreate(value_t, arena, 4), specials);

--- a/lifp/virtual_machine.c
+++ b/lifp/virtual_machine.c
@@ -33,7 +33,7 @@ result_vm_ref_t vmCreate(vm_options_t opts) {
 
   try(result_vm_ref_t, environmentCreate(arena, nullptr), machine->global);
 
-  try(result_vm_ref_t, mapCreate(value_t, arena, 32), builtins);
+  try(result_vm_ref_t, mapCreate(value_t, arena, 64), builtins);
 
 #define setBuiltin(Label, Builtin)                                             \
   builtin.type = VALUE_TYPE_BUILTIN;                                           \
@@ -61,6 +61,7 @@ result_vm_ref_t vmCreate(vm_options_t opts) {
   setBuiltin(LIST_MAP, listMap);
   setBuiltin(LIST_EACH, listEach);
   setBuiltin(LIST_FILTER, listFilter);
+  setBuiltin(LIST_TIMES, listTimes);
   setBuiltin(MATH_MAX, mathMax);
   setBuiltin(MATH_MIN, mathMin);
   setBuiltin(MATH_CEIL, mathCeil);

--- a/tests/integration.test.c
+++ b/tests/integration.test.c
@@ -78,7 +78,7 @@ int main() {
 
   case("immediate invocation");
   value_t immediate_invocation;
-  execute(&immediate_invocation, "((fn (a b) (list.from a b)) 2 3)");
+  execute(&immediate_invocation, "((fn (a b) (list:from a b)) 2 3)");
   expectEqlUint(immediate_invocation.type, VALUE_TYPE_LIST, "returns a list");
   expectTrue((immediate_invocation.value.list.data[0].value.number == 2 && 
     immediate_invocation.value.list.data[1].value.number == 3) != 0, "with correct value");
@@ -101,7 +101,7 @@ int main() {
   
   case("functions with non-inline types");
   value_t fun2;
-  execute(&fun2, "(def! comma (fn (s) (str.join \", \" s)))\n(comma (\"1\" \"2\"))");
+  execute(&fun2, "(def! comma (fn (s) (str:join \", \" s)))\n(comma (\"1\" \"2\"))");
   expectEqlUint(fun2.type, VALUE_TYPE_STRING, "returns correct type");
 
   case("let");

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -93,7 +93,7 @@ void transientAllocations(void) {
                 "persisted for simple evaluations");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  tryAssert(execute("(list.from 1 2 3 4 5)"));
+  tryAssert(execute("(list:from 1 2 3 4 5)"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + (sizeof(value_t) * 5) +
                     sizeof(List(value_t)),
@@ -105,9 +105,6 @@ void transientAllocations(void) {
                 usage + (sizeof(value_t) * 2) + sizeof(List(value_t)),
                 "persisted for closure invocations");
   usage = getArenaMemoryUsage(test_result_arena);
-
-  // TODO: there is no way of nesting builtins for non stack allocated values
-  // yet
 
   arenaReset(test_ast_arena);
   arenaReset(test_temp_arena);
@@ -145,7 +142,7 @@ void letBindingsMemory(void) {
                 "persisted for simple evaluations");
   usage = getArenaMemoryUsage(test_result_arena);
   
-  tryAssert(execute("(let ((x 10) (y 20)) (list.from x y))"));
+  tryAssert(execute("(let ((x 10) (y 20)) (list:from x y))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t) * 2),
                 "persisted for builtin invocations");
@@ -157,7 +154,7 @@ void letBindingsMemory(void) {
                 "persisted for nested let bindings");
   usage = getArenaMemoryUsage(test_result_arena);
 
-  tryAssert(execute("(let ((f (fn (a) (+ a 1)))) (list.from (f 10)))"));
+  tryAssert(execute("(let ((f (fn (a) (+ a 1)))) (list:from (f 10)))"));
   expectEqlSize(getArenaMemoryUsage(test_result_arena),
                 usage + sizeof(List(value_t)) + (sizeof(value_t)),
                 "persisted for let with closures");

--- a/tests/memory.test.c
+++ b/tests/memory.test.c
@@ -322,7 +322,7 @@ void errorHandlingMemory(void) {
 }
 
 void danglingArenas(void) {
-  tryFail(execute("((fn (a) a) 1 2)"));
+  tryFail(execute("((fn (a b c) a) 1 2)"));
   expectEqlSize(getUsedArenas(), 4, "no dangling arena on failure");
 
   tryAssert(execute("(def! rec (fn (a) (cond ((= a 0) 1) (rec (- a 1)))))\n(rec 10)"));

--- a/tests/specials.test.c
+++ b/tests/specials.test.c
@@ -74,6 +74,10 @@ void defSpecialForm() {
   expectIncludeString(exec.message, "already been declared",
                       "prevents overriding builtins");
 
+  tryFail(execute(&result, "(def! lo:l 2)"), exec);
+  expectIncludeString(exec.message, "Unexpected namespace delimiter",
+                      "bindings cannot include namespace symbol");
+
   tryFail(execute(&result, "(let ((foo 1)) (def! foo 2))"), exec);
   expectIncludeString(exec.message, "already been declared",
                       "prevents overriding locals");
@@ -196,6 +200,10 @@ void letSpecialForm() {
   tryFail(execute(&result, "(let ((y 1)) (let ((y 2)) y))"), exec);
   expectIncludeString(exec.message, "already been declared",
                       "prevents shadowing locals");
+
+  tryFail(execute(&result, "(let ((lo:l 1)) lo:l)"), exec);
+  expectIncludeString(exec.message, "Unexpected namespace delimiter",
+                      "bindings cannot include namespace symbol");
 }
 
 void condSpecialForm() {


### PR DESCRIPTION
While adding the methods, I came across a parsing problem with `.` whereby custom identifiers could mess with (upcoming!) module namespacing.

This change uses a non-ambiguous char `:` for namespacing, as opposed to `.` which could not be forbidden because it's a legit character in numbers (e.g. `23.123`)